### PR TITLE
Please reject : Enable subclasses of AbstractJdbcOutputPlugin to extend ColumnSetterFactory

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -10,10 +10,13 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+
 import org.slf4j.Logger;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+
 import org.embulk.config.CommitReport;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -32,9 +35,11 @@ import org.embulk.spi.TransactionalPageOutput;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.output.jdbc.setter.ColumnSetter;
 import org.embulk.output.jdbc.setter.ColumnSetterFactory;
 import org.embulk.output.jdbc.RetryExecutor.IdempotentOperation;
+
 import static org.embulk.output.jdbc.RetryExecutor.retryExecutor;
 
 public abstract class AbstractJdbcOutputPlugin
@@ -443,7 +448,7 @@ public abstract class AbstractJdbcOutputPlugin
         }
         try {
             PageReader reader = new PageReader(schema);
-            ColumnSetterFactory factory = new ColumnSetterFactory(batch, reader, null);  // TODO TimestampFormatter
+            ColumnSetterFactory factory = newColumnSetterFactory(batch, reader, null);  // TODO TimestampFormatter
 
             JdbcSchema loadSchema = task.getLoadSchema();
 
@@ -507,6 +512,12 @@ public abstract class AbstractJdbcOutputPlugin
         }
     }
 
+    protected ColumnSetterFactory newColumnSetterFactory(BatchInsert batch, PageReader pageReader,
+            TimestampFormatter timestampFormatter)
+    {
+    	return new ColumnSetterFactory(batch, pageReader, timestampFormatter);
+    }
+    
     public static class PluginPageOutput
             implements TransactionalPageOutput
     {

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -92,6 +92,38 @@ public class JdbcOutputConnection
 
         sb.append("CREATE TABLE IF NOT EXISTS ");
         quoteIdentifierString(sb, name);
+        sb.append(buildColumnsOfCreateTableSql(schema));
+        return sb.toString();
+    }
+
+    public void createTable(String tableName, JdbcSchema schema) throws SQLException
+    {
+        Statement stmt = connection.createStatement();
+        try {
+            String sql = buildCreateTableSql(tableName, schema);
+            executeUpdate(stmt, sql);
+            commitIfNecessary(connection);
+        } catch (SQLException ex) {
+            throw safeRollback(connection, ex);
+        } finally {
+            stmt.close();
+        }
+    }
+
+    protected String buildCreateTableSql(String name, JdbcSchema schema)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("CREATE TABLE ");
+        quoteIdentifierString(sb, name);
+        sb.append(buildColumnsOfCreateTableSql(schema));
+        return sb.toString();
+    }
+    
+    private String buildColumnsOfCreateTableSql(JdbcSchema schema)
+    {
+        StringBuilder sb = new StringBuilder();
+
         sb.append(" (");
         boolean first = true;
         for (JdbcColumn c : schema.getColumns()) {


### PR DESCRIPTION
Because column types vary by DBMS, it is needed that subclass of the AbstractJdbcOutputPlugin class can extend the ColumnSetterFactory class.