### PR TITLE
Add createTable method for subclasses of JdbcOutputConnection

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -92,6 +92,38 @@ public class JdbcOutputConnection
 
         sb.append("CREATE TABLE IF NOT EXISTS ");
         quoteIdentifierString(sb, name);
+        sb.append(buildColumnsOfCreateTableSql(schema));
+        return sb.toString();
+    }
+
+    public void createTable(String tableName, JdbcSchema schema) throws SQLException
+    {
+        Statement stmt = connection.createStatement();
+        try {
+            String sql = buildCreateTableSql(tableName, schema);
+            executeUpdate(stmt, sql);
+            commitIfNecessary(connection);
+        } catch (SQLException ex) {
+            throw safeRollback(connection, ex);
+        } finally {
+            stmt.close();
+        }
+    }
+
+    protected String buildCreateTableSql(String name, JdbcSchema schema)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("CREATE TABLE ");
+        quoteIdentifierString(sb, name);
+        sb.append(buildColumnsOfCreateTableSql(schema));
+        return sb.toString();
+    }
+    
+    private String buildColumnsOfCreateTableSql(JdbcSchema schema)
+    {
+        StringBuilder sb = new StringBuilder();
+
         sb.append(" (");
         boolean first = true;
         for (JdbcColumn c : schema.getColumns()) {


### PR DESCRIPTION
Add createTable method for subclasses of the JdbcOutputConnection class, because some DBMSs such as Oracle doesn't have "CREATE TABLE IF NOT EXISTS" statement.