### PR TITLE
Add dropTable method for subclasses of JdbcOutputConnection

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -62,7 +62,7 @@ public class JdbcOutputConnection
     {
         Statement stmt = connection.createStatement();
         try {
-        	dropTableIfExists(stmt, tableName);
+            dropTableIfExists(stmt, tableName);
             commitIfNecessary(connection);
         } catch (SQLException ex) {
             throw safeRollback(connection, ex);
@@ -81,7 +81,7 @@ public class JdbcOutputConnection
     {
         Statement stmt = connection.createStatement();
         try {
-        	dropTable(stmt, tableName);
+            dropTable(stmt, tableName);
             commitIfNecessary(connection);
         } catch (SQLException ex) {
             throw safeRollback(connection, ex);
@@ -311,7 +311,7 @@ public class JdbcOutputConnection
     {
         Statement stmt = connection.createStatement();
         try {
-        	dropTableIfExists(stmt, toTable);
+            dropTableIfExists(stmt, toTable);
 
             StringBuilder sb = new StringBuilder();
             sb.append("ALTER TABLE ");

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -62,14 +62,38 @@ public class JdbcOutputConnection
     {
         Statement stmt = connection.createStatement();
         try {
-            String sql = String.format("DROP TABLE IF EXISTS %s", quoteIdentifierString(tableName));
-            executeUpdate(stmt, sql);
+        	dropTableIfExists(stmt, tableName);
             commitIfNecessary(connection);
         } catch (SQLException ex) {
             throw safeRollback(connection, ex);
         } finally {
             stmt.close();
         }
+    }
+
+    protected void dropTableIfExists(Statement stmt, String tableName) throws SQLException
+    {
+        String sql = String.format("DROP TABLE IF EXISTS %s", quoteIdentifierString(tableName));
+        executeUpdate(stmt, sql);
+    }
+
+    public void dropTable(String tableName) throws SQLException
+    {
+        Statement stmt = connection.createStatement();
+        try {
+        	dropTable(stmt, tableName);
+            commitIfNecessary(connection);
+        } catch (SQLException ex) {
+            throw safeRollback(connection, ex);
+        } finally {
+            stmt.close();
+        }
+    }
+
+    protected void dropTable(Statement stmt, String tableName) throws SQLException
+    {
+        String sql = String.format("DROP TABLE %s", quoteIdentifierString(tableName));
+        executeUpdate(stmt, sql);
     }
 
     public void createTableIfNotExists(String tableName, JdbcSchema schema) throws SQLException
@@ -287,23 +311,15 @@ public class JdbcOutputConnection
     {
         Statement stmt = connection.createStatement();
         try {
-            {
-                StringBuilder sb = new StringBuilder();
-                sb.append("DROP TABLE IF EXISTS ");
-                quoteIdentifierString(sb, toTable);
-                String sql = sb.toString();
-                executeUpdate(stmt, sql);
-            }
+        	dropTableIfExists(stmt, toTable);
 
-            {
-                StringBuilder sb = new StringBuilder();
-                sb.append("ALTER TABLE ");
-                quoteIdentifierString(sb, fromTable);
-                sb.append(" RENAME TO ");
-                quoteIdentifierString(sb, toTable);
-                String sql = sb.toString();
-                executeUpdate(stmt, sql);
-            }
+            StringBuilder sb = new StringBuilder();
+            sb.append("ALTER TABLE ");
+            quoteIdentifierString(sb, fromTable);
+            sb.append(" RENAME TO ");
+            quoteIdentifierString(sb, toTable);
+            String sql = sb.toString();
+            executeUpdate(stmt, sql);
 
             commitIfNecessary(connection);
         } catch (SQLException ex) {


### PR DESCRIPTION
Add dropTable method for subclasses of the JdbcOutputConnection class, because some DBMSs such as Oracle don't have "DROP TABLE IF NOT EXISTS" statement.
And modify replaceTable method to call dropTableIfExists method internally.