### PR TITLE
 Make tableExists method public for Oracle

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -314,7 +314,7 @@ public abstract class AbstractJdbcOutputPlugin
         task.setLoadSchema(matchSchemaByColumnNames(schema, targetTableSchema));
     }
 
-    protected String generateSwapTableName(PluginTask task)
+    protected String generateSwapTableName(PluginTask task) throws SQLException
     {
     	return task.getTable() + "_" + getTransactionUniqueName() + "_bulk_load_temp";
     }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -60,7 +60,7 @@ public class JdbcOutputConnection
         }
     }
 
-    protected boolean tableExists(String tableName) throws SQLException
+    public boolean tableExists(String tableName) throws SQLException
     {
         try (ResultSet rs = connection.getMetaData().getTables(null, schemaName, tableName, null)) {
             return rs.next();


### PR DESCRIPTION
Because Oracle allows only 30 character for a table name, it is a bit difficult to generate a unique table name.
I've implemented the generateSwapTableName method by generating a swap table name using an original table name and a sequential number, and checking if the table name exists.

https://github.com/hito4t/embulk-output-oracle/blob/branch1/src/main/java/org/embulk/output/OracleOutputPlugin.java
