### PR TITLE
support merge mode for mysql/postgresql

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -128,7 +128,12 @@ public abstract class AbstractJdbcOutputPlugin
 
         public boolean isInplace()
         {
-            return this == INSERT_DIRECT || this == REPLACE_INPLACE;
+            return this == INSERT_DIRECT || this == REPLACE_INPLACE || this == MERGE;
+        }
+
+        public boolean isMerge()
+        {
+            return this == MERGE;
         }
 
         public boolean usesMultipleLoadTables()
@@ -156,8 +161,11 @@ public abstract class AbstractJdbcOutputPlugin
         case "replace":
             task.setMode(Mode.REPLACE_INPLACE);
             break;
+        case "merge":
+            task.setMode(Mode.MERGE);
+            break;
         default:
-            throw new ConfigException(String.format("Unknown mode '%s'. Supported modes are: insert, replace", task.getModeConfig()));
+            throw new ConfigException(String.format("Unknown mode '%s'. Supported modes are: insert, replace, merge", task.getModeConfig()));
         }
 
         //switch(task.getModeConfig()) {
@@ -383,35 +391,35 @@ public abstract class AbstractJdbcOutputPlugin
                 {
                     columns.add(new JdbcColumn(
                             columnName, "BOOLEAN",
-                            Types.BOOLEAN, 1, 0));
+                            Types.BOOLEAN, 1, 0, false));
                 }
 
                 public void longColumn(Column column)
                 {
                     columns.add(new JdbcColumn(
                             columnName, "BIGINT",
-                            Types.BIGINT, 22, 0));
+                            Types.BIGINT, 22, 0, false));
                 }
 
                 public void doubleColumn(Column column)
                 {
                     columns.add(new JdbcColumn(
                             columnName, "DOUBLE PRECISION",
-                            Types.FLOAT, 24, 0));
+                            Types.FLOAT, 24, 0, false));
                 }
 
                 public void stringColumn(Column column)
                 {
                     columns.add(new JdbcColumn(
                                 columnName, "CLOB",
-                                Types.CLOB, 4000, 0));  // TODO size type param
+                                Types.CLOB, 4000, 0, false));  // TODO size type param
                 }
 
                 public void timestampColumn(Column column)
                 {
                     columns.add(new JdbcColumn(
                                 columnName, "TIMESTAMP",
-                                Types.TIMESTAMP, 26, 0));  // size type param is from postgresql.
+                                Types.TIMESTAMP, 26, 0, false));  // size type param is from postgresql.
                 }
             });
         }
@@ -423,15 +431,27 @@ public abstract class AbstractJdbcOutputPlugin
     {
         DatabaseMetaData dbm = connection.getMetaData();
         String escape = dbm.getSearchStringEscape();
-
-        ImmutableList.Builder<JdbcColumn> columns = ImmutableList.builder();
         String schemaNamePattern = JdbcUtils.escapeSearchString(connection.getSchemaName(), escape);
+
+        ResultSet rs = dbm.getPrimaryKeys(null, schemaNamePattern, tableName);
+        ImmutableList.Builder<String> primaryKeysBuilder = ImmutableList.builder();
+        try {
+            while(rs.next()) {
+                primaryKeysBuilder.add(rs.getString("COLUMN_NAME"));
+            }
+        } finally {
+            rs.close();
+        }
+        ImmutableList<String> primaryKeys = primaryKeysBuilder.build();
+
         String tableNamePattern = JdbcUtils.escapeSearchString(tableName, escape);
-        ResultSet rs = dbm.getColumns(null, schemaNamePattern, tableNamePattern, null);
+        ImmutableList.Builder<JdbcColumn> columns = ImmutableList.builder();
+        rs = dbm.getColumns(null, schemaNamePattern, tableNamePattern, null);
         try {
             while(rs.next()) {
                 String columnName = rs.getString("COLUMN_NAME");
                 String typeName = rs.getString("TYPE_NAME");
+                boolean isPrimaryKey = primaryKeys.contains(columnName);
                 typeName = typeName.toUpperCase(Locale.ENGLISH);
                 int sqlType = rs.getInt("DATA_TYPE");
                 int colSize = rs.getInt("COLUMN_SIZE");
@@ -443,7 +463,7 @@ public abstract class AbstractJdbcOutputPlugin
                 //rs.getString("COLUMN_DEF") // or null  // TODO
                 columns.add(new JdbcColumn(
                             columnName, typeName,
-                            sqlType, colSize, decDigit));
+                            sqlType, colSize, decDigit, isPrimaryKey));
             }
         } finally {
             rs.close();
@@ -511,12 +531,11 @@ public abstract class AbstractJdbcOutputPlugin
                         // insert_direct
                         loadTable = task.getTable();
                     }
-
                     b.prepare(loadTable, insertSchema);
                 }
             });
 
-            PluginPageOutput output = new PluginPageOutput(reader, batch, columnSetters.build(),
+            PluginPageOutput output = newPluginPageOutput(reader, batch, columnSetters.build(),
                     task.getBatchSize());
             batch = null;
             return output;
@@ -541,13 +560,20 @@ public abstract class AbstractJdbcOutputPlugin
     	return new ColumnSetterFactory(batch, pageReader, timestampFormatter);
     }
 
+    protected PluginPageOutput newPluginPageOutput(PageReader reader,
+                                                   BatchInsert batch, List<ColumnSetter> columnSetters,
+                                                   int batchSize)
+    {
+        return new PluginPageOutput(reader, batch, columnSetters, batchSize);
+    }
+
     public static class PluginPageOutput
             implements TransactionalPageOutput
     {
+        protected final List<Column> columns;
+        protected final List<ColumnSetter> columnSetters;
         private final PageReader pageReader;
         private final BatchInsert batch;
-        private final List<Column> columns;
-        private final List<ColumnSetter> columnSetters;
         private final int batchSize;
         private final int foraceBatchFlushSize;
 
@@ -572,9 +598,7 @@ public abstract class AbstractJdbcOutputPlugin
                     if (batch.getBatchWeight() > foraceBatchFlushSize) {
                         batch.flush();
                     }
-                    for (int i=0; i < columnSetters.size(); i++) {
-                        columns.get(i).visit(columnSetters.get(i));
-                    }
+                    handleColumnsSetters();
                     batch.add();
                 }
                 if (batch.getBatchWeight() > batchSize) {
@@ -615,6 +639,15 @@ public abstract class AbstractJdbcOutputPlugin
         {
             return Exec.newCommitReport();
         }
+
+        protected void handleColumnsSetters()
+        {
+            int size = columnSetters.size();
+            for (int i=0; i < size; i++) {
+                columns.get(i).visit(columnSetters.get(i));
+            }
+        }
+
     }
 
     public static interface IdempotentSqlRunnable

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumn.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumn.java
@@ -11,6 +11,7 @@ public class JdbcColumn
     private int sqlType;
     private int sizeTypeParameter;
     private int scaleTypeParameter;
+    private boolean isPrimaryKey;
 
     @JsonCreator
     public JdbcColumn(
@@ -18,25 +19,33 @@ public class JdbcColumn
             @JsonProperty("typeName") String typeName,
             @JsonProperty("sqlType") int sqlType,
             @JsonProperty("sizeTypeParameter") int sizeTypeParameter,
-            @JsonProperty("scaleTypeParameter") int scaleTypeParameter)
+            @JsonProperty("scaleTypeParameter") int scaleTypeParameter,
+            @JsonProperty("primaryKey") boolean isPrimaryKey)
     {
         this.name = name;
         this.typeName = typeName;
         this.sqlType = sqlType;
         this.sizeTypeParameter = sizeTypeParameter;
         this.scaleTypeParameter = scaleTypeParameter;
+        this.isPrimaryKey = isPrimaryKey;
     }
 
     @JsonIgnore
     public static JdbcColumn skipColumn()
     {
-        return new JdbcColumn(null, null, 0, 0, 0);
+        return new JdbcColumn(null, null, 0, 0, 0, false);
     }
 
     @JsonIgnore
     public boolean isSkipColumn()
     {
         return name == null;
+    }
+
+    @JsonProperty("primaryKey")
+    public boolean isPrimaryKey()
+    {
+        return isPrimaryKey;
     }
 
     @JsonProperty("name")

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -306,6 +306,13 @@ public class JdbcOutputConnection
         return connection.prepareStatement(insertSql);
     }
 
+    public PreparedStatement prepareUpsertSql(String toTable, JdbcSchema toTableSchema) throws SQLException
+    {
+        String upsertSql = buildPrepareUpsertSql(toTable, toTableSchema);
+        logger.info("Prepared SQL: {}", upsertSql);
+        return connection.prepareStatement(upsertSql);
+    }
+
     protected String buildPrepareInsertSql(String toTable, JdbcSchema toTableSchema) throws SQLException
     {
         StringBuilder sb = new StringBuilder();
@@ -326,6 +333,11 @@ public class JdbcOutputConnection
         sb.append(")");
 
         return sb.toString();
+    }
+
+    protected String buildPrepareUpsertSql(String toTable, JdbcSchema toTableSchema) throws SQLException
+    {
+        throw new UnsupportedOperationException("not implemented yet");
     }
 
     // TODO

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
@@ -32,11 +32,17 @@ public class StandardBatchInsert
     public void prepare(String loadTable, JdbcSchema insertSchema) throws SQLException
     {
         this.connection = connector.connect(true);
-        this.batch = connection.prepareInsertSql(loadTable, insertSchema);
+        this.batch = newPreparedStatement(connection, loadTable, insertSchema);
         this.index = 1;  // PreparedStatement index begings from 1
         this.batchRows = 0;
         this.totalRows = 0;
         batch.clearBatch();
+    }
+
+    protected PreparedStatement newPreparedStatement(JdbcOutputConnection connection,
+                                                     String loadTable, JdbcSchema insertSchema) throws SQLException
+    {
+        return connection.prepareInsertSql(loadTable, insertSchema);
     }
 
     public int getBatchWeight()

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/ColumnSetter.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/ColumnSetter.java
@@ -24,6 +24,11 @@ public abstract class ColumnSetter
         this.column = column;
     }
 
+    public JdbcColumn getColumn()
+    {
+        return column;
+    }
+
     public int getSqlType()
     {
         return column.getSqlType();

--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
@@ -4,6 +4,8 @@ import java.util.Properties;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Connection;
+
+import org.embulk.output.mysql.MySQLBatchUpsert;
 import org.embulk.spi.Exec;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -96,6 +98,7 @@ public class MySQLOutputPlugin
     @Override
     protected BatchInsert newBatchInsert(PluginTask task) throws IOException, SQLException
     {
-        return new MySQLBatchInsert(getConnector(task, true));
+        MySQLOutputConnector connector = getConnector(task, true);
+        return task.getMode().isMerge() ? new MySQLBatchUpsert(connector) : new MySQLBatchInsert(connector);
     }
 }

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLBatchUpsert.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLBatchUpsert.java
@@ -1,0 +1,22 @@
+package org.embulk.output.mysql;
+
+import org.embulk.output.jdbc.JdbcOutputConnection;
+import org.embulk.output.jdbc.JdbcSchema;
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class MySQLBatchUpsert extends MySQLBatchInsert {
+
+    public MySQLBatchUpsert(MySQLOutputConnector connector) throws IOException, SQLException {
+        super(connector);
+    }
+
+    @Override
+    protected PreparedStatement newPreparedStatement(JdbcOutputConnection connection,
+                                                     String loadTable, JdbcSchema insertSchema) throws SQLException
+    {
+        return connection.prepareUpsertSql(loadTable, insertSchema);
+    }
+
+}

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
@@ -2,6 +2,8 @@ package org.embulk.output.mysql;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import org.embulk.output.jdbc.JdbcSchema;
 import org.embulk.spi.Exec;
 import org.embulk.output.jdbc.BatchInsert;
 import org.embulk.output.jdbc.JdbcOutputConnection;
@@ -15,6 +17,36 @@ public class MySQLOutputConnection
     {
         super(connection, null);
         connection.setAutoCommit(autoCommit);
+    }
+
+    @Override
+    protected String buildPrepareUpsertSql(String toTable, JdbcSchema toTableSchema) throws SQLException
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("INSERT INTO ");
+        quoteIdentifierString(sb, toTable);
+
+        sb.append(" (");
+        for (int i=0; i < toTableSchema.getCount(); i++) {
+            if(i != 0) { sb.append(", "); }
+            quoteIdentifierString(sb, toTableSchema.getColumnName(i));
+        }
+        sb.append(") VALUES (");
+        for(int i=0; i < toTableSchema.getCount(); i++) {
+            if(i != 0) { sb.append(", "); }
+            sb.append("?");
+        }
+        sb.append(")");
+
+        sb.append(" ON DUPLICATE KEY UPDATE ");
+        for (int i=0; i < toTableSchema.getCount(); i++) {
+            if(i != 0) { sb.append(", "); }
+            final String columnName = quoteIdentifierString(toTableSchema.getColumnName(i));
+            sb.append(columnName).append(" = VALUES(").append(columnName).append(")");
+        }
+
+        return sb.toString();
     }
 
     @Override

--- a/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
@@ -1,6 +1,7 @@
 package org.embulk.output;
 
 import java.io.IOException;
+import java.lang.UnsupportedOperationException;
 import java.sql.SQLException;
 import java.util.Properties;
 import com.google.common.base.Optional;
@@ -98,6 +99,9 @@ public class OracleOutputPlugin
     @Override
     protected BatchInsert newBatchInsert(PluginTask task) throws IOException, SQLException
     {
+        if (task.getMode().isMerge()) {
+            throw new UnsupportedOperationException("mode 'merge' is not implemented for this type");
+        }
         return new StandardBatchInsert(getConnector(task, true));
     }
 

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -54,4 +54,55 @@ public class PostgreSQLOutputConnection
             return typeName;
         }
     }
+
+    @Override
+    protected String buildPrepareUpsertSql(String toTable, JdbcSchema toTableSchema) throws SQLException
+    {
+        StringBuilder sb = new StringBuilder();
+        int size = toTableSchema.getCount();
+        String table = quoteIdentifierString(toTable);
+        int idx = 0;
+
+        sb.append("WITH upsert AS (UPDATE ").append(table).append(" SET ");
+
+        for (int i=0; i < size; i++) {
+            JdbcColumn c = toTableSchema.getColumn(i);
+            if (!c.isPrimaryKey()) {
+                if(idx != 0) { sb.append(", "); }
+                idx++;
+                quoteIdentifierString(sb, toTableSchema.getColumnName(i));
+                sb.append("=?");
+            }
+        }
+
+        sb.append(" WHERE ");
+        idx = 0;
+        for(int i=0; i < size; i++) {
+            JdbcColumn c = toTableSchema.getColumn(i);
+            if (c.isPrimaryKey()) {
+                if(idx != 0) { sb.append(" AND "); }
+                idx++;
+                quoteIdentifierString(sb, toTableSchema.getColumnName(i));
+                sb.append("=?");
+            }
+        }
+        sb.append(" RETURNING true as result)");
+
+        sb.append(" INSERT INTO ").append(table).append(" (");
+        for (int i=0; i < size; i++) {
+            if(i != 0) { sb.append(", "); }
+            quoteIdentifierString(sb, toTableSchema.getColumnName(i));
+        }
+        sb.append(")");
+
+        sb.append(" SELECT ");
+        for (int i=0; i < size; i++) {
+            if(i != 0) { sb.append(", "); }
+            sb.append("?");
+        }
+        sb.append(" WHERE (SELECT result FROM upsert) is null");
+
+        return sb.toString();
+    }
+
 }

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgresqlBatchUpsert.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgresqlBatchUpsert.java
@@ -1,0 +1,24 @@
+package org.embulk.output.postgresql;
+
+import org.embulk.output.jdbc.JdbcOutputConnection;
+import org.embulk.output.jdbc.JdbcOutputConnector;
+import org.embulk.output.jdbc.JdbcSchema;
+import org.embulk.output.jdbc.StandardBatchInsert;
+
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class PostgresqlBatchUpsert extends StandardBatchInsert {
+
+    public PostgresqlBatchUpsert(JdbcOutputConnector connector) throws IOException, SQLException {
+        super(connector);
+    }
+
+    protected PreparedStatement newPreparedStatement(JdbcOutputConnection connection,
+                                                     String loadTable, JdbcSchema insertSchema) throws SQLException
+    {
+        return connection.prepareUpsertSql(loadTable, insertSchema);
+    }
+
+}

--- a/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
@@ -104,6 +104,9 @@ public class RedshiftOutputPlugin
     @Override
     protected BatchInsert newBatchInsert(PluginTask task) throws IOException, SQLException
     {
+        if (task.getMode().isMerge()) {
+            throw new UnsupportedOperationException("mode 'merge' is not implemented for this type");
+        }
         RedshiftPluginTask t = (RedshiftPluginTask) task;
         AWSCredentials creds = new BasicAWSCredentials(
                 t.getAccessKeyId(), t.getSecretAccessKey());


### PR DESCRIPTION
This PR implements `merge` mode to output records into database by executing upsert query.

The summary of each databases is as below:

1. mysql
 - execute INSERT ~ ON DUPLICATE KEY UPDATE query

2. postgresql
 - execute WITH query by pk on the tabke
 - support for only >=9.1, bacause WITH UPDATE〜 query is supported from this version

3. other databases
 - I'm not implemented yet, I'll do it soon.