### PR TITLE
Implement SkipColumnSetter#nullValue

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SkipColumnSetter.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SkipColumnSetter.java
@@ -1,5 +1,8 @@
 package org.embulk.output.jdbc.setter;
 
+import java.io.IOException;
+import java.sql.SQLException;
+
 import org.embulk.spi.PageReader;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.output.jdbc.JdbcColumn;
@@ -30,6 +33,10 @@ public class SkipColumnSetter
     }
 
     protected void timestampValue(Timestamp v)
+    {
+    }
+
+    protected void nullValue()
     {
     }
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SkipColumnSetter.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SkipColumnSetter.java
@@ -1,11 +1,7 @@
 package org.embulk.output.jdbc.setter;
 
-import java.io.IOException;
-import java.sql.SQLException;
-
 import org.embulk.spi.PageReader;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.output.jdbc.JdbcColumn;
 import org.embulk.output.jdbc.BatchInsert;
 
 public class SkipColumnSetter


### PR DESCRIPTION
Implement SkipColumnSetter#nullValue to skip the column and avoid NullPointerException.
<pre>
Caused by: java.lang.NullPointerException
    at org.embulk.output.jdbc.setter.ColumnSetter.getSqlType(ColumnSetter.java:34)
    at org.embulk.output.jdbc.setter.ColumnSetter.nullValue(ColumnSetter.java:110)
    at org.embulk.output.jdbc.setter.ColumnSetter.stringColumn(ColumnSetter.java:83)
    at org.embulk.spi.Column.visit(Column.java:57)
</pre>