### PR TITLE
Change column names of embulk-output-oracle test ymls

### DIFF
--- a/embulk-output-oracle/src/test/resources/yml/test-insert-direct.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-insert-direct.yml
@@ -8,12 +8,12 @@ in:
     delimiter: ','
     quote: ''
     columns:
-    - {name: id, type: string}
-    - {name: varchar2_item, type: string}
-    - {name: integer_item, type: long}
-    - {name: number_item, type: string}
-    - {name: date_item, type: timestamp, format: '%Y/%m/%d'}
-    - {name: timestamp_item, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
 out:
     type: oracle
     host: localhost

--- a/embulk-output-oracle/src/test/resources/yml/test-insert-oci-split.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-insert-oci-split.yml
@@ -8,12 +8,12 @@ in:
     delimiter: ','
     quote: ''
     columns:
-    - {name: id, type: string}
-    - {name: varchar2_item, type: string}
-    - {name: integer_item, type: long}
-    - {name: number_item, type: string}
-    - {name: date_item, type: timestamp, format: '%Y/%m/%d'}
-    - {name: timestamp_item, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
 out:
     type: oracle
     host: localhost

--- a/embulk-output-oracle/src/test/resources/yml/test-insert-oci.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-insert-oci.yml
@@ -8,12 +8,12 @@ in:
     delimiter: ','
     quote: ''
     columns:
-    - {name: id, type: string}
-    - {name: varchar2_item, type: string}
-    - {name: integer_item, type: long}
-    - {name: number_item, type: string}
-    - {name: date_item, type: timestamp, format: '%Y/%m/%d'}
-    - {name: timestamp_item, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
 out:
     type: oracle
     host: localhost

--- a/embulk-output-oracle/src/test/resources/yml/test-insert.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-insert.yml
@@ -8,12 +8,12 @@ in:
     delimiter: ','
     quote: ''
     columns:
-    - {name: id, type: string}
-    - {name: varchar2_item, type: string}
-    - {name: integer_item, type: long}
-    - {name: number_item, type: string}
-    - {name: date_item, type: timestamp, format: '%Y/%m/%d'}
-    - {name: timestamp_item, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
 out:
     type: oracle
     host: localhost

--- a/embulk-output-oracle/src/test/resources/yml/test-replace-long-name.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-replace-long-name.yml
@@ -8,12 +8,12 @@ in:
     delimiter: ','
     quote: ''
     columns:
-    - {name: id, type: string}
-    - {name: varchar2_item, type: string}
-    - {name: integer_item, type: long}
-    - {name: number_item, type: string}
-    - {name: date_item, type: timestamp, format: '%Y/%m/%d'}
-    - {name: timestamp_item, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
 out:
     type: oracle
     host: localhost

--- a/embulk-output-oracle/src/test/resources/yml/test-replace.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-replace.yml
@@ -8,12 +8,12 @@ in:
     delimiter: ','
     quote: ''
     columns:
-    - {name: id, type: string}
-    - {name: varchar2_item, type: string}
-    - {name: integer_item, type: long}
-    - {name: number_item, type: string}
-    - {name: date_item, type: timestamp, format: '%Y/%m/%d'}
-    - {name: timestamp_item, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
 out:
     type: oracle
     host: localhost

--- a/embulk-output-oracle/src/test/resources/yml/test-url.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-url.yml
@@ -8,12 +8,12 @@ in:
     delimiter: ','
     quote: ''
     columns:
-    - {name: id, type: string}
-    - {name: varchar2_item, type: string}
-    - {name: integer_item, type: long}
-    - {name: number_item, type: string}
-    - {name: date_item, type: timestamp, format: '%Y/%m/%d'}
-    - {name: timestamp_item, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
 out:
     type: oracle
     user: TEST_USER


### PR DESCRIPTION
Column names of embulk-output-oracle test table are upper cases, but column names of embulk-output-oracle test ymls were lower cases.
By #21, a yml column which doesn't match exactly a column name of table is skipped.
So I've changed yml column names to upper cases.