### PR TITLE
Support swap table name length limitation for all RDMSs

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -295,7 +295,7 @@ public abstract class AbstractJdbcOutputPlugin
             // DROP TABLE IF EXISTS xyz__0000000054d92dee1e452158_bulk_load_temp
             // CREATE TABLE IF NOT EXISTS xyz__0000000054d92dee1e452158_bulk_load_temp
             // swapTableName = "xyz__0000000054d92dee1e452158_bulk_load_temp"
-            String swapTableName = generateSwapTableName(task);
+            String swapTableName = generateSwapTableName(task, con);
             con.dropTableIfExists(swapTableName);
             con.createTableIfNotExists(swapTableName, newJdbcSchemaForNewTable(schema));
             targetTableSchema = newJdbcSchemaFromExistentTable(con, swapTableName);
@@ -320,9 +320,42 @@ public abstract class AbstractJdbcOutputPlugin
         task.setLoadSchema(matchSchemaByColumnNames(schema, targetTableSchema));
     }
 
-    protected String generateSwapTableName(PluginTask task) throws SQLException
+    protected String generateSwapTableName(PluginTask task, JdbcOutputConnection con) throws SQLException
     {
-    	return task.getTable() + "_" + getTransactionUniqueName() + "_bulk_load_temp";
+        String tableName = task.getTable();
+        String suffix = "_bl_tmp";
+        String uniqueSuffix = getTransactionUniqueName() + suffix;
+
+        // way to count length of table name varies by DBMSs (bytes or characters),
+        // so truncate swap table name by one character.
+        while (!isValidIdentifier(con, tableName + "_" + uniqueSuffix)) {
+            if (uniqueSuffix.length() > 8 + suffix.length()) {
+                // truncate transaction unique name
+                // (include 8 characters of the transaction name at least)
+                uniqueSuffix = uniqueSuffix.substring(1);
+            } else {
+                if (tableName.isEmpty()) {
+                    throw new ConfigException("Table name is too long to generate temporary table name");
+                }
+                // truncate table name
+                tableName = tableName.substring(0, tableName.length() - 1);
+                //if (!connection.tableExists(tableName)) {
+                // TODO this doesn't help. Rather than truncating more characters,
+                //      here needs to replace characters with random characters. But
+                //      to make the result deterministic. So, an idea is replacing
+                //      the last character to the first (second, third, ... for each loop)
+                //      of md5(original table name).
+                //}
+            }
+
+        }
+        return tableName + "_" + uniqueSuffix;
+    }
+
+    // subclass should override and return if identifier (ex. table name) is valid for the DBMS.
+    protected boolean isValidIdentifier(JdbcOutputConnection con, String identifier) throws SQLException
+    {
+        return true;
     }
 
     protected void doCommit(JdbcOutputConnection con, PluginTask task, int taskCount)
@@ -566,7 +599,7 @@ public abstract class AbstractJdbcOutputPlugin
     protected ColumnSetterFactory newColumnSetterFactory(BatchInsert batch, PageReader pageReader,
             TimestampFormatter timestampFormatter)
     {
-    	return new ColumnSetterFactory(batch, pageReader, timestampFormatter);
+        return new ColumnSetterFactory(batch, pageReader, timestampFormatter);
     }
 
     protected PluginPageOutput newPluginPageOutput(PageReader reader,

--- a/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
@@ -1,7 +1,7 @@
 package org.embulk.output;
 
 import java.io.IOException;
-import java.lang.UnsupportedOperationException;
+import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.Properties;
 
@@ -155,8 +155,9 @@ public class OracleOutputPlugin
     @Override
     protected boolean isValidIdentifier(JdbcOutputConnection con, String identifier) throws SQLException
     {
-        // TODO: support multibyte identifier
-        return identifier.length() < MAX_TABLE_NAME_LENGTH;
+        OracleCharset charset = ((OracleOutputConnection)con).getCharset();
+        ByteBuffer buffer = charset.javaCharset.encode(identifier);
+        return buffer.remaining() <= MAX_TABLE_NAME_LENGTH;
     }
 
 }

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
@@ -28,6 +28,7 @@ public class OracleOutputConnection
     }
 
     private final boolean direct;
+    private OracleCharset charset;
 
 
     public OracleOutputConnection(Connection connection, boolean autoCommit, boolean direct)
@@ -105,30 +106,33 @@ public class OracleOutputConnection
 
     public OracleCharset getCharset() throws SQLException
     {
-        String charsetName = "UTF8";
-        try (Statement statement = connection.createStatement()) {
-            try (ResultSet resultSet = statement.executeQuery("SELECT VALUE FROM NLS_DATABASE_PARAMETERS WHERE PARAMETER='NLS_CHARACTERSET'")) {
-                if (resultSet.next()) {
-                    String nlsCharacterSet = resultSet.getString(1);
-                    if (CHARSET_NAMES.containsKey(nlsCharacterSet)) {
-                        charsetName = nlsCharacterSet;
+        if (charset == null) {
+            String charsetName = "UTF8";
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet resultSet = statement.executeQuery("SELECT VALUE FROM NLS_DATABASE_PARAMETERS WHERE PARAMETER='NLS_CHARACTERSET'")) {
+                    if (resultSet.next()) {
+                        String nlsCharacterSet = resultSet.getString(1);
+                        if (CHARSET_NAMES.containsKey(nlsCharacterSet)) {
+                            charsetName = nlsCharacterSet;
+                        }
                     }
                 }
             }
-        }
 
-        try (PreparedStatement statement = connection.prepareStatement("SELECT NLS_CHARSET_ID(?) FROM DUAL")) {
-            statement.setString(1, charsetName);
-            try (ResultSet resultSet = statement.executeQuery()) {
-                if (!resultSet.next()) {
-                    throw new SQLException("Unknown NLS_CHARACTERSET : " + charsetName);
+            try (PreparedStatement statement = connection.prepareStatement("SELECT NLS_CHARSET_ID(?) FROM DUAL")) {
+                statement.setString(1, charsetName);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (!resultSet.next()) {
+                        throw new SQLException("Unknown NLS_CHARACTERSET : " + charsetName);
+                    }
+
+                    charset = new OracleCharset(charsetName,
+                            resultSet.getShort(1),
+                            Charset.forName(CHARSET_NAMES.get(charsetName)));
                 }
-
-                return new OracleCharset(charsetName,
-                        resultSet.getShort(1),
-                        Charset.forName(CHARSET_NAMES.get(charsetName)));
             }
         }
+        return charset;
     }
 
 }

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTest.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTest.java
@@ -153,6 +153,12 @@ public class OracleOutputPluginTest
     }
 
     @Test
+    public void testReplaceLongNameMultibyte() throws Exception
+    {
+        invoke("testReplaceLongNameMultibyte");
+    }
+
+    @Test
     public void testReplaceCreate() throws Exception
     {
         invoke("testReplaceCreate");

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
@@ -178,6 +178,18 @@ public class OracleOutputPluginTestImpl
         assertGeneratedTable(table);
     }
 
+    public void testReplaceLongNameMultibyte() throws Exception
+    {
+        String table = "ＴＥＳＴ12345678901234567890";
+
+        dropTable(table);
+        createTable(table);
+
+        run("/yml/test-replace-long-name-multibyte.yml");
+
+        assertGeneratedTable(table);
+    }
+
     private void dropTable(String table) throws SQLException
     {
         String sql = String.format("DROP TABLE %s", table);

--- a/embulk-output-oracle/src/test/resources/yml/test-replace-long-name-multibyte.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-replace-long-name-multibyte.yml
@@ -1,0 +1,25 @@
+in:
+  type: file
+  path_prefix: '/data/test1/test1.csv'
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: ''
+    columns:
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+out:
+    type: oracle
+    host: localhost
+    database: TESTDB
+    user: TEST_USER
+    password: test_pw
+    table: ＴＥＳＴ12345678901234567890
+    mode: replace
+    #driver_path: driver/ojdbc7.jar


### PR DESCRIPTION
Only OracleJdbcPlugin#generateSwapTableName supported table name length limitation, but other RDMSs also have such limitation.
So I've moved contents of OracleJdbcPlugin#generateSwapTableName to AbstractJdbcPlugin.
In addition, I've corrected embulk-output-oracle to measure length of multibyte table name correctly.