### PR TITLE
fix insert-mode in postgresql doesn't work

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -544,8 +544,7 @@ public abstract class AbstractJdbcOutputPlugin
                 }
             });
 
-            PluginPageOutput output = newPluginPageOutput(reader, batch, columnSetters.build(),
-                    task.getBatchSize());
+            PluginPageOutput output = newPluginPageOutput(reader, batch, columnSetters.build(), task);
             batch = null;
             return output;
 
@@ -571,9 +570,9 @@ public abstract class AbstractJdbcOutputPlugin
 
     protected PluginPageOutput newPluginPageOutput(PageReader reader,
                                                    BatchInsert batch, List<ColumnSetter> columnSetters,
-                                                   int batchSize)
+                                                   PluginTask task)
     {
-        return new PluginPageOutput(reader, batch, columnSetters, batchSize);
+        return new PluginPageOutput(reader, batch, columnSetters, task.getBatchSize());
     }
 
     public static class PluginPageOutput

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
@@ -93,15 +93,19 @@ public class PostgreSQLOutputPlugin
     @Override
     protected PluginPageOutput newPluginPageOutput(PageReader reader,
                                                    BatchInsert batch, List<ColumnSetter> columnSetters,
-                                                   int batchSize)
+                                                   PluginTask task)
     {
-        return new PostgresPluginPageOutput(reader, batch, columnSetters, batchSize);
+        if (task.getMode().isMerge()) {
+            return new PostgresPluginPageOutput(reader, batch, columnSetters, task.getBatchSize());
+        }
+        return super.newPluginPageOutput(reader, batch, columnSetters, task);
     }
 
     public static class PostgresPluginPageOutput extends PluginPageOutput
     {
 
-        public PostgresPluginPageOutput(PageReader pageReader, BatchInsert batch, List<ColumnSetter> columnSetters, int batchSize) {
+        public PostgresPluginPageOutput(PageReader pageReader, BatchInsert batch, List<ColumnSetter> columnSetters, int batchSize)
+        {
             super(pageReader, batch, columnSetters, batchSize);
         }
 


### PR DESCRIPTION
This PR will fix a problem of insert-mode for postgresql which results from implementation of merge-mode.

Now, too many columns will be written to tmp tsv file by this bug, so I wrote this batch to resolve it.