### PR TITLE
YourKit acknowledgment

### DIFF
--- a/embulk-output-oracle/README.md
+++ b/embulk-output-oracle/README.md
@@ -109,7 +109,7 @@ For Linux (x64) (only Ubuntu Server 14.04 is tested)
 
 (6) Execute src/main/cpp/linux/build.sh .
 
-
-embulk-output-oracle uses YourKit to improve performance.
-YourKit supports open source projects with its full-featured Java Profiler.
-YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a> and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>, innovative and intelligent tools for profiling Java and .NET applications.
+***
+<img src="https://www.yourkit.com/images/yklogo.png" alt="YourKit"/> is used to improve performance of embulk-output-oracle.  
+YourKit supports open source projects with its full-featured Java Profiler.  
+YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a> and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>, innovative and intelligent tools for profiling Java and .NET applications.  

--- a/embulk-output-oracle/README.md
+++ b/embulk-output-oracle/README.md
@@ -108,3 +108,8 @@ For Linux (x64) (only Ubuntu Server 14.04 is tested)
 * OCI_PATH (the directory of Oracle Instant Client Basic and the parent of the "sdk" directory)
 
 (6) Execute src/main/cpp/linux/build.sh .
+
+
+embulk-output-oracle uses YourKit to improve performance.
+YourKit supports open source projects with its full-featured Java Profiler.
+YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a> and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>, innovative and intelligent tools for profiling Java and .NET applications.


### PR DESCRIPTION
We need YourKit to improve the performance of embulk-output-oracle.
In order to use YourKit open source project license, we should put acknowledgment for YourKit on the project web site.

The email from YourKit team is as follows.

> we require to place on the project web site a small free-form text acknowledgment/testimonial.
> 
> The acknowledgment should contain:
> 
> - Attached YourKit logo and text that your open source project is using YourKit profiler. Alternatively logo hosted at https://www.yourkit.com/images/yklogo.png
can be used.
> 
> - Should contain a reference to YourKit web site.
> 
> For example:
> "
> YourKit supports open source projects with its full-featured Java Profiler.
> YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a> and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>, innovative and intelligent tools for profiling Java and .NET applications.
> "
