### PR TITLE
Fix MySQLSyntaxErrorException if table doesn't exist.

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -664,6 +664,8 @@ public abstract class AbstractJdbcOutputPlugin
     public Optional<JdbcSchema> newJdbcSchemaFromTableIfExists(JdbcOutputConnection connection,
             String tableName) throws SQLException
     {
+        if (! connection.tableExists(tableName)) return Optional.absent();
+
         DatabaseMetaData dbm = connection.getMetaData();
         String escape = dbm.getSearchStringEscape();
 


### PR DESCRIPTION
I got the following error when importing a csv file to mysql. The change fixes the error.

```
% ~/bin/embulk run import_config.yml 
2015-06-10 03:42:02.543 +0000: Embulk v0.6.11
2015-06-10 03:42:05.201 +0000: Loaded plugin embulk-output-mysql (0.3.0)
2015-06-10 03:42:05.304 +0000 [INFO] (transaction): Listing local files at directory '/tmp/20150609-11662-1lnx5ic' filtering filename by prefix 'datafile'
2015-06-10 03:42:05.312 +0000 [INFO] (transaction): Loading files [/tmp/20150609-11662-1lnx5ic/datafile]
2015-06-10 03:42:05.449 +0000 [INFO] (transaction): Connecting to jdbc:mysql://localhost:3306/yyamano1 options {user=root, tcpKeepAlive=true, useCompression=true, rewriteBatchedStatements=true, connectTimeout=300000, socketTimeout=1800000}
2015-06-10 03:42:05.845 +0000 [INFO] (transaction): Using insert_direct mode
2015-06-10 03:42:05.863 +0000 [ERROR] (transaction): Operation failed (1146:42S02)
java.lang.RuntimeException: com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Table 'yyamano1.my_table' doesn't exist
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.begin(org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java:333)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.transaction(org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java:290)
	at org.embulk.exec.BulkLoader$4$1$1.transaction(org/embulk/exec/BulkLoader.java:490)
	at org.embulk.exec.LocalExecutorPlugin.transaction(org/embulk/exec/LocalExecutorPlugin.java:37)
	at org.embulk.exec.BulkLoader$4$1.run(org/embulk/exec/BulkLoader.java:486)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:97)
	at org.embulk.spi.util.Filters.transaction(org/embulk/spi/util/Filters.java:50)
	at org.embulk.exec.BulkLoader$4.run(org/embulk/exec/BulkLoader.java:481)
	at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(org/embulk/spi/FileInputRunner.java:117)
	at org.embulk.standards.CsvParserPlugin.transaction(org/embulk/standards/CsvParserPlugin.java:115)
	at org.embulk.spi.FileInputRunner$RunnerControl$1.run(org/embulk/spi/FileInputRunner.java:111)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(org/embulk/spi/util/Decoders.java:77)
	at org.embulk.spi.util.Decoders$RecursiveControl$1.run(org/embulk/spi/util/Decoders.java:73)
	at org.embulk.standards.GzipFileDecoderPlugin.transaction(org/embulk/standards/GzipFileDecoderPlugin.java:30)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(org/embulk/spi/util/Decoders.java:68)
	at org.embulk.spi.util.Decoders.transaction(org/embulk/spi/util/Decoders.java:33)
	at org.embulk.spi.FileInputRunner$RunnerControl.run(org/embulk/spi/FileInputRunner.java:108)
	at org.embulk.standards.LocalFileInputPlugin.resume(org/embulk/standards/LocalFileInputPlugin.java:80)
	at org.embulk.standards.LocalFileInputPlugin.transaction(org/embulk/standards/LocalFileInputPlugin.java:70)
	at org.embulk.spi.FileInputRunner.transaction(org/embulk/spi/FileInputRunner.java:63)
	at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:477)
	at org.embulk.exec.BulkLoader.access$100(org/embulk/exec/BulkLoader.java:36)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:342)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:338)
	at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:24)
	at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:338)
	at org.embulk.command.Runner.run(org/embulk/command/Runner.java:148)
	at org.embulk.command.Runner.main(org/embulk/command/Runner.java:101)
	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:497)
	at RUBY.run(file:/home/vagrant/api-ez/bin/embulk!/embulk/command/embulk_run.rb:339)
	at classpath_3a_embulk.command.embulk.(root)(classpath:embulk/command/embulk.rb:43)
	at classpath_3a_embulk.command.embulk.(root)(classpath_3a_embulk/command/classpath:embulk/command/embulk.rb:43)
	at org.embulk.cli.Main.main(org/embulk/cli/Main.java:11)
Caused by: com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Table 'yyamano1.my_table' doesn't exist
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at com.mysql.jdbc.Util.handleNewInstance(Util.java:377)
	at com.mysql.jdbc.Util.getInstance(Util.java:360)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:978)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3887)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3823)
	at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2435)
	at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2582)
	at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2526)
	at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2484)
	at com.mysql.jdbc.StatementImpl.executeQuery(StatementImpl.java:1446)
	at com.mysql.jdbc.DatabaseMetaData$7.forEach(DatabaseMetaData.java:3759)
	at com.mysql.jdbc.DatabaseMetaData$7.forEach(DatabaseMetaData.java:3749)
	at com.mysql.jdbc.IterateBlock.doForAll(IterateBlock.java:50)
	at com.mysql.jdbc.DatabaseMetaData.getPrimaryKeys(DatabaseMetaData.java:3747)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.newJdbcSchemaFromTableIfExists(AbstractJdbcOutputPlugin.java:670)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.doBegin(AbstractJdbcOutputPlugin.java:396)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin$1.run(AbstractJdbcOutputPlugin.java:326)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin$8.call(AbstractJdbcOutputPlugin.java:892)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin$8.call(AbstractJdbcOutputPlugin.java:889)
	at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:100)
	at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:77)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.withRetry(AbstractJdbcOutputPlugin.java:885)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.withRetry(AbstractJdbcOutputPlugin.java:878)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.begin(AbstractJdbcOutputPlugin.java:321)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.transaction(AbstractJdbcOutputPlugin.java:290)
	at org.embulk.exec.BulkLoader$4$1$1.transaction(BulkLoader.java:490)
	at org.embulk.exec.LocalExecutorPlugin.transaction(LocalExecutorPlugin.java:37)
	at org.embulk.exec.BulkLoader$4$1.run(BulkLoader.java:486)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:97)
	at org.embulk.spi.util.Filters.transaction(Filters.java:50)
	at org.embulk.exec.BulkLoader$4.run(BulkLoader.java:481)
	at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:117)
	at org.embulk.standards.CsvParserPlugin.transaction(CsvParserPlugin.java:115)
	at org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:111)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:77)
	at org.embulk.spi.util.Decoders$RecursiveControl$1.run(Decoders.java:73)
	at org.embulk.standards.GzipFileDecoderPlugin.transaction(GzipFileDecoderPlugin.java:30)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:68)
	at org.embulk.spi.util.Decoders.transaction(Decoders.java:33)
	at org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:108)
	at org.embulk.standards.LocalFileInputPlugin.resume(LocalFileInputPlugin.java:80)
	at org.embulk.standards.LocalFileInputPlugin.transaction(LocalFileInputPlugin.java:70)
	at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:63)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:477)
	at org.embulk.exec.BulkLoader.access$100(BulkLoader.java:36)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:342)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:338)
	at org.embulk.spi.Exec.doWith(Exec.java:24)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:338)
	at org.embulk.command.Runner.run(Runner.java:148)
	at org.embulk.command.Runner.main(Runner.java:101)
```