### PR TITLE
Make timestamp column setters independent from JVM's default time zone

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/BatchInsert.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/BatchInsert.java
@@ -1,12 +1,11 @@
 package org.embulk.output.jdbc;
 
 import java.math.BigDecimal;
+import java.util.Calendar;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.PreparedStatement;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
+import org.embulk.spi.time.Timestamp;
 
 public interface BatchInsert
 {
@@ -46,9 +45,9 @@ public interface BatchInsert
 
     public void setBytes(byte[] v) throws IOException, SQLException;
 
-    public void setSqlDate(Date v, int sqlType) throws IOException, SQLException;
+    public void setSqlDate(Timestamp v, Calendar cal) throws IOException, SQLException;
 
-    public void setSqlTime(Time v, int sqlType) throws IOException, SQLException;
+    public void setSqlTime(Timestamp v, Calendar cal) throws IOException, SQLException;
 
-    public void setSqlTimestamp(Timestamp v, int sqlType) throws IOException, SQLException;
+    public void setSqlTimestamp(Timestamp v, Calendar cal) throws IOException, SQLException;
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/ColumnSetterFactory.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/ColumnSetterFactory.java
@@ -1,5 +1,7 @@
 package org.embulk.output.jdbc.setter;
 
+import java.util.Calendar;
+import java.util.Locale;
 import java.sql.Types;
 import org.joda.time.DateTimeZone;
 import org.embulk.spi.time.TimestampFormatter;
@@ -53,17 +55,17 @@ public class ColumnSetterFactory
         case "nstring":
             return new NStringColumnSetter(batch, column, newDefaultValueSetter(column, option), newTimestampFormatter(option));
         case "date":
-            return new SqlDateColumnSetter(batch, column, newDefaultValueSetter(column, option), getTimeZone(option));
+            return new SqlDateColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
         case "time":
-            return new SqlTimeColumnSetter(batch, column, newDefaultValueSetter(column, option));
+            return new SqlTimeColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
         case "timestamp":
-            return new SqlTimestampColumnSetter(batch, column, newDefaultValueSetter(column, option));
+            return new SqlTimestampColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
         case "decimal":
             return new BigDecimalColumnSetter(batch, column, newDefaultValueSetter(column, option));
         case "null":
             return new NullColumnSetter(batch, column, newDefaultValueSetter(column, option));
         case "pass":
-            return new PassThroughColumnSetter(batch, column, newDefaultValueSetter(column, option));
+            return new PassThroughColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
         default:
             throw new ConfigException(String.format("Unknown value_type '%s' for column '%s'", option.getValueType(), column.getName()));
         }
@@ -74,7 +76,12 @@ public class ColumnSetterFactory
         return new TimestampFormatter(
                 option.getJRuby(),
                 option.getTimestampFormat().getFormat(),
-                option.getTimeZone().or(defaultTimeZone));
+                getTimeZone(option));
+    }
+
+    protected Calendar newCalendar(JdbcColumnOption option)
+    {
+        return Calendar.getInstance(getTimeZone(option).toTimeZone(), Locale.ENGLISH);
     }
 
     protected DateTimeZone getTimeZone(JdbcColumnOption option)
@@ -138,11 +145,11 @@ public class ColumnSetterFactory
 
         // Time
         case Types.DATE:
-            return new SqlDateColumnSetter(batch, column, newDefaultValueSetter(column, option), getTimeZone(option));
+            return new SqlDateColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
         case Types.TIME:
-            return new SqlTimeColumnSetter(batch, column, newDefaultValueSetter(column, option));
+            return new SqlTimeColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
         case Types.TIMESTAMP:
-            return new SqlTimestampColumnSetter(batch, column, newDefaultValueSetter(column, option));
+            return new SqlTimestampColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
 
         // Null
         case Types.NULL:

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/PassThroughColumnSetter.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/PassThroughColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.output.jdbc.setter;
 
+import java.util.Calendar;
 import java.io.IOException;
 import java.sql.SQLException;
 import org.embulk.spi.time.Timestamp;
@@ -10,10 +11,14 @@ import org.embulk.output.jdbc.BatchInsert;
 public class PassThroughColumnSetter
         extends ColumnSetter
 {
+    private final Calendar calendar;
+
     public PassThroughColumnSetter(BatchInsert batch, JdbcColumn column,
-            DefaultValueSetter defaultValue)
+            DefaultValueSetter defaultValue,
+            Calendar calendar)
     {
         super(batch, column, defaultValue);
+        this.calendar = calendar;
     }
 
     @Override
@@ -49,8 +54,6 @@ public class PassThroughColumnSetter
     @Override
     public void timestampValue(Timestamp v) throws IOException, SQLException
     {
-        java.sql.Timestamp t = new java.sql.Timestamp(v.toEpochMilli());
-        t.setNanos(v.getNano());
-        batch.setSqlTimestamp(t, getSqlType());
+        batch.setSqlTimestamp(v, calendar);
     }
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SqlDateColumnSetter.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SqlDateColumnSetter.java
@@ -1,9 +1,9 @@
 package org.embulk.output.jdbc.setter;
 
+import java.util.Calendar;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Date;
-import org.joda.time.DateTimeZone;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.output.jdbc.JdbcColumn;
 import org.embulk.output.jdbc.BatchInsert;
@@ -11,14 +11,14 @@ import org.embulk.output.jdbc.BatchInsert;
 public class SqlDateColumnSetter
         extends ColumnSetter
 {
-    private final DateTimeZone timeZone;
+    private final Calendar calendar;
 
     public SqlDateColumnSetter(BatchInsert batch, JdbcColumn column,
             DefaultValueSetter defaultValue,
-            DateTimeZone timeZone)
+            Calendar calendar)
     {
         super(batch, column, defaultValue);
-        this.timeZone = timeZone;
+        this.calendar = calendar;
     }
 
     @Override
@@ -54,10 +54,6 @@ public class SqlDateColumnSetter
     @Override
     public void timestampValue(Timestamp v) throws IOException, SQLException
     {
-        // JavaDoc of java.sql.Time says:
-        // >> To conform with the definition of SQL DATE, the millisecond values wrapped by a java.sql.Date instance must be 'normalized' by setting the hours, minutes, seconds, and milliseconds to zero in the particular time zone with which the instance is associated.
-        long normalized = timeZone.convertUTCToLocal(v.toEpochMilli());
-        Date d = new Date(normalized);
-        batch.setSqlDate(d, getSqlType());
+        batch.setSqlDate(v, calendar);
     }
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SqlTimeColumnSetter.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SqlTimeColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.output.jdbc.setter;
 
+import java.util.Calendar;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Time;
@@ -10,10 +11,14 @@ import org.embulk.output.jdbc.BatchInsert;
 public class SqlTimeColumnSetter
         extends ColumnSetter
 {
+    private final Calendar calendar;
+
     public SqlTimeColumnSetter(BatchInsert batch, JdbcColumn column,
-            DefaultValueSetter defaultValue)
+            DefaultValueSetter defaultValue,
+            Calendar calendar)
     {
         super(batch, column, defaultValue);
+        this.calendar = calendar;
     }
 
     @Override
@@ -49,7 +54,6 @@ public class SqlTimeColumnSetter
     @Override
     public void timestampValue(Timestamp v) throws IOException, SQLException
     {
-        Time t = new Time(v.toEpochMilli());
-        batch.setSqlTime(t, getSqlType());
+        batch.setSqlTime(v, calendar);
     }
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SqlTimestampColumnSetter.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/SqlTimestampColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.output.jdbc.setter;
 
+import java.util.Calendar;
 import java.io.IOException;
 import java.sql.SQLException;
 import org.embulk.spi.time.Timestamp;
@@ -9,10 +10,14 @@ import org.embulk.output.jdbc.BatchInsert;
 public class SqlTimestampColumnSetter
         extends ColumnSetter
 {
+    private final Calendar calendar;
+
     public SqlTimestampColumnSetter(BatchInsert batch, JdbcColumn column,
-            DefaultValueSetter defaultValue)
+            DefaultValueSetter defaultValue,
+            Calendar calendar)
     {
         super(batch, column, defaultValue);
+        this.calendar = calendar;
     }
 
     @Override
@@ -48,8 +53,6 @@ public class SqlTimestampColumnSetter
     @Override
     public void timestampValue(Timestamp v) throws IOException, SQLException
     {
-        java.sql.Timestamp t = new java.sql.Timestamp(v.toEpochMilli());
-        t.setNanos(v.getNano());
-        batch.setSqlTimestamp(t, getSqlType());
+        batch.setSqlTimestamp(v, calendar);
     }
 }

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
@@ -196,7 +196,7 @@ public class OracleOutputPluginTestImpl
 
         run("/yml/test-string-timestamp.yml");
 
-        assertTable(table, TimeZone.getDefault());
+        assertTable(table);
     }
 
     private void dropTable(String table) throws SQLException
@@ -220,12 +220,9 @@ public class OracleOutputPluginTestImpl
 
     private void assertTable(String table) throws Exception
     {
-        assertTable(table, TimeZone.getTimeZone("GMT"));
-    }
-
-
-    private void assertTable(String table, TimeZone timeZone) throws Exception
-    {
+    	// datetime of UTC will be inserted by embulk.
+    	// datetime of default timezone will be selected by JDBC.
+    	TimeZone timeZone = TimeZone.getDefault();
         List<List<Object>> rows = select(table);
 
         /*
@@ -267,11 +264,9 @@ public class OracleOutputPluginTestImpl
 
     private void assertGeneratedTable1(String table) throws Exception
     {
-        assertGeneratedTable1(table, TimeZone.getTimeZone("GMT"));
-    }
-
-    private void assertGeneratedTable1(String table, TimeZone timeZone) throws Exception
-    {
+    	// datetime of UTC will be inserted by embulk.
+    	// datetime of default timezone will be selected by JDBC.
+    	TimeZone timeZone = TimeZone.getDefault();
         List<List<Object>> rows = select(table);
 
         /*
@@ -313,11 +308,9 @@ public class OracleOutputPluginTestImpl
 
     private void assertGeneratedTable2(String table) throws Exception
     {
-        assertGeneratedTable2(table, TimeZone.getTimeZone("GMT"));
-    }
-
-    private void assertGeneratedTable2(String table, TimeZone timeZone) throws Exception
-    {
+    	// datetime of UTC will be inserted by embulk.
+    	// datetime of default timezone will be selected by JDBC.
+    	TimeZone timeZone = TimeZone.getDefault();
         List<List<Object>> rows = select(table);
 
         /*

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -150,6 +150,8 @@ public class PostgreSQLOutputConnection
             return "TEXT";
         case "BLOB":
             return "BYTEA";
+        case "TIMESTAMP":
+            return "TIMESTAMP WITH TIME ZONE";
         default:
             return super.buildColumnTypeName(c);
         }

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -150,8 +150,6 @@ public class PostgreSQLOutputConnection
             return "TEXT";
         case "BLOB":
             return "BYTEA";
-        case "TIMESTAMP":
-            return "TIMESTAMP WITH TIME ZONE";
         default:
             return super.buildColumnTypeName(c);
         }


### PR DESCRIPTION
JDBC spec defines that `PreparedStatement#setTime`, `#setDate`, and `#setTime` use JVM's default time zone if Calendar instance is not set. 

https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html#setTimestamp-int-java.sql.Timestamp-java.util.Calendar-

>> If no Calendar object is specified, the driver uses the default timezone, which is that of the virtual machine running the application.

This change forces them to use default_timezone or column_options.timezone parameter so that behavior becomes independent from execution environment.

As a part of change, embulk-output-postgresql uses TIMESTAMP WITH TIME ZONE type by default instead of TIMESTAMP type.