### PR TITLE
Support Oracle VARCHAR2 in creating temporary table

### DIFF
--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
@@ -6,6 +6,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -161,5 +162,18 @@ public class OracleOutputConnection
             }
         }
         return charset;
+    }
+
+    private static final String[] STANDARD_SIZE_TYPE_NAMES = {
+        "VARCHAR2", "NVARCHAR2",
+    };
+
+    @Override
+    protected ColumnDeclareType getColumnDeclareType(String convertedTypeName, JdbcColumn col)
+    {
+        if (Arrays.asList(STANDARD_SIZE_TYPE_NAMES).contains(convertedTypeName)) {
+            return ColumnDeclareType.SIZE;
+        }
+        return super.getColumnDeclareType(convertedTypeName, col);
     }
 }

--- a/embulk-output-oracle/src/test/resources/yml/test-insert.yml
+++ b/embulk-output-oracle/src/test/resources/yml/test-insert.yml
@@ -23,5 +23,3 @@ out:
     table: TEST1
     mode: insert
     #driver_path: driver/ojdbc7.jar
-    column_options:
-      VARCHAR2_ITEM: {type: VARCHAR2(40)}


### PR DESCRIPTION
If try to output into a table with VARCHAR2 column in `mode: insert`, embulk-output-oracle will fail to create a temporary table.
(work around is to define type in column_options of yml)

This PR fixes the problem.

