### PR TITLE
Add ssl: option to postgresql

### DIFF
--- a/embulk-output-postgresql/README.md
+++ b/embulk-output-postgresql/README.md
@@ -19,6 +19,7 @@ PostgreSQL output plugins for Embulk loads records to PostgreSQL.
 - **table**: destination table name (string, required)
 - **options**: extra connection properties (hash, default: {})
 - **mode**: "replace", "merge" or "insert" (string, required)
+- **ssl**: enables SSL. data will be encrypted but CA or certification will not be verified (boolean, default: false)
 - **batch_size**: size of a single batch insert (integer, default: 16777216)
 - **default_timezone**: If input column type (embulk type) is timestamp, this plugin needs to format the timestamp into a SQL string. This default_timezone option is used to control the timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.

--- a/embulk-output-postgresql/build.gradle
+++ b/embulk-output-postgresql/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':embulk-output-jdbc')
 
-    compile 'org.postgresql:postgresql:9.4-1200-jdbc41'
+    compile 'org.postgresql:postgresql:9.4-1205-jdbc41'
 
     testCompile project(':embulk-output-jdbc').sourceSets.test.output
 }

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
@@ -49,7 +49,7 @@ public class PostgreSQLOutputPlugin
         public String getSchema();
 
         @Config("ssl")
-        @ConfigDefault("\"false\"")
+        @ConfigDefault("false")
         public boolean getSsl();
     }
 

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
@@ -47,6 +47,10 @@ public class PostgreSQLOutputPlugin
         @Config("schema")
         @ConfigDefault("\"public\"")
         public String getSchema();
+
+        @Config("ssl")
+        @ConfigDefault("\"false\"")
+        public boolean getSsl();
     }
 
     @Override
@@ -80,16 +84,13 @@ public class PostgreSQLOutputPlugin
         // Socket options TCP_KEEPCNT, TCP_KEEPIDLE, and TCP_KEEPINTVL are not configurable.
         props.setProperty("tcpKeepAlive", "true");
 
-        // TODO
-        //switch t.getSssl() {
-        //when "disable":
-        //    break;
-        //when "enable":
-        //    props.setProperty("sslfactory", "org.postgresql.ssl.NonValidatingFactory");  // disable server-side validation
-        //when "verify":
-        //    props.setProperty("ssl", "true");
-        //    break;
-        //}
+        if (t.getSsl()) {
+            // TODO add ssl_verify (boolean) option to allow users to verify certification.
+            //      see embulk-input-ftp for SSL implementation.
+            props.setProperty("ssl", "true");
+            props.setProperty("sslfactory", "org.postgresql.ssl.NonValidatingFactory");  // disable server-side validation
+        }
+        // setting ssl=false enables SSL. See org.postgresql.core.v3.openConnectionImpl.
 
         if (!retryableMetadataOperation) {
             // non-retryable batch operation uses longer timeout


### PR DESCRIPTION
Setting `ssl: true` sets ssl=true and sslfactory=org.postgresql.ssl.NonValidatingFactory
JDBC options.