### PR TITLE
Support multibyte object name in Oracle OCI mode

### DIFF
--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
@@ -398,7 +398,8 @@ public class OCIWrapper
 
     private Pointer createPointer(String s)
     {
-        return Pointer.wrap(Runtime.getSystemRuntime(), ByteBuffer.wrap(s.getBytes()));
+        // not database charset, but system charset of client
+        return Pointer.wrap(Runtime.getSystemRuntime(), ByteBuffer.wrap(s.getBytes(systemCharset)));
     }
 
     private Pointer createPointer(short n)

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
@@ -398,8 +398,7 @@ public class OCIWrapper
 
     private Pointer createPointer(String s)
     {
-        // not database charset, but system charset of client
-        return Pointer.wrap(Runtime.getSystemRuntime(), ByteBuffer.wrap(s.getBytes(systemCharset)));
+        return Pointer.wrap(Runtime.getSystemRuntime(), ByteBuffer.wrap(s.getBytes()));
     }
 
     private Pointer createPointer(short n)


### PR DESCRIPTION
Actually, charset of object names depends on client environment.
Namely, if a client with UTF-8 creates multibyte table name, and another client with EUC selects the table, it will fail.