### PR TITLE
S3 creds allow no iam_user_name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ import com.github.jrubygradle.JRubyExec
 
 allprojects {
     group = 'org.embulk.output.jdbc'
-    version = '0.5.0'
+    version = '0.5.1'
 }
 
 subprojects {

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
@@ -6,9 +6,11 @@ import java.sql.Driver;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
+
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.output.jdbc.AbstractJdbcOutputPlugin;
@@ -70,7 +72,9 @@ public class JdbcOutputPlugin
         GenericPluginTask t = (GenericPluginTask) task;
 
         if (t.getDriverPath().isPresent()) {
-            loadDriverJar(t.getDriverPath().get());
+            String[] paths = t.getDriverPath().get().split(",");
+            for(String path: paths)
+                loadDriverJar(path);
         }
 
         Properties props = new Properties();

--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -19,7 +19,7 @@ Redshift output plugins for Embulk loads records to Redshift.
 - **table**: destination table name (string, required)
 - **access_key_id**: access key id for AWS
 - **secret_access_key**: secret access key for AWS
-- **iam_user_name**: IAM user name for uploading temporary files to S3. The user should have permissions of `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` and `sts:GetFederationToken`.
+- **iam_user_name**: IAM user name for uploading temporary files to S3. The user should have permissions of `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` and `sts:GetFederationToken`. (string, default: "")
 - **s3_bucket**: S3 bucket name for temporary files
 - **s3_key_prefix**: S3 key prefix for temporary files (string, default:"")
 - **options**: extra connection properties (hash, default: {})
@@ -63,7 +63,6 @@ out:
   table: my_table
   access_key_id: ABCXYZ123ABCXYZ123
   secret_access_key: AbCxYz123aBcXyZ123
-  iam_user_name: my-s3-read-only
   s3_bucket: my-redshift-transfer-bucket
   s3_key_prefix: temp/redshift
   mode: insert

--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -32,6 +32,7 @@ Redshift output plugins for Embulk loads records to Redshift.
   - **timestamp_format**: If input column type (embulk type) is timestamp and value_type is `string` or `nstring`, this plugin needs to format the timestamp value into a string. This timestamp_format option is used to control the format of the timestamp. (string, default: `%Y-%m-%d %H:%M:%S.%6N`)
   - **timezone**: If input column type (embulk type) is timestamp, this plugin needs to format the timestamp value into a SQL string. In this cases, this timezone option is used to control the timezone. (string, value of default_timezone option is used by default)
 
+
 ### Modes
 
 * **insert**:
@@ -97,3 +98,8 @@ out:
 ```
 $ ./gradlew gem
 ```
+
+### Security
+This plugin requires AWS access credentials so that it may write temporary files to S3. There are two security options, Standard and Federated. 
+To use Standard security, give **aws_key_id** and **secret_access_key**. To use Federated mode, also give the **iam_user_name** field.
+Federated mode really means temporary credentials, so that a man-in-the-middle attack will see AWS credentials that are only valid for 1 calendar day after the transaction.

--- a/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
@@ -53,6 +53,7 @@ public class RedshiftOutputPlugin
         public String getSecretAccessKey();
 
         @Config("iam_user_name")
+        @ConfigDefault("\"\"")
         public String getIamUserName();
 
         @Config("s3_bucket")

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
@@ -10,7 +10,6 @@ import java.io.OutputStreamWriter;
 import java.io.Closeable;
 import java.io.BufferedWriter;
 import java.sql.SQLException;
-
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.policy.Policy;
@@ -23,14 +22,13 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
 import com.amazonaws.services.securitytoken.model.GetFederationTokenRequest;
 import com.amazonaws.services.securitytoken.model.GetFederationTokenResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
-
 import org.slf4j.Logger;
 import org.embulk.spi.Exec;
 import org.embulk.output.jdbc.JdbcSchema;
 import org.embulk.output.postgresql.AbstractPostgreSQLCopyBatchInsert;
 
 public class RedshiftCopyBatchInsert
-extends AbstractPostgreSQLCopyBatchInsert
+        extends AbstractPostgreSQLCopyBatchInsert
 {
     private final Logger logger = Exec.getLogger(RedshiftCopyBatchInsert.class);
     private final RedshiftOutputConnector connector;

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
@@ -25,7 +25,6 @@ import com.amazonaws.services.securitytoken.model.GetFederationTokenResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
 
 import org.slf4j.Logger;
-import org.apache.http.client.CredentialsProvider;
 import org.embulk.spi.Exec;
 import org.embulk.output.jdbc.JdbcSchema;
 import org.embulk.output.postgresql.AbstractPostgreSQLCopyBatchInsert;
@@ -81,8 +80,8 @@ extends AbstractPostgreSQLCopyBatchInsert
         // Redshift supports gzip
         return new BufferedWriter(
                 new OutputStreamWriter(
-                        new GZIPOutputStream(new FileOutputStream(newFile)),
-                        FILE_CHARSET)
+                    new GZIPOutputStream(new FileOutputStream(newFile)),
+                    FILE_CHARSET)
                 );
     }
 
@@ -121,21 +120,17 @@ extends AbstractPostgreSQLCopyBatchInsert
         }
     }
 
-    private BasicSessionCredentials generateSimpleSessionCredentials(String awsAccessKey, String awsSecretKey) {
-        return new BasicSessionCredentials(awsAccessKey, awsSecretKey, null);
-    }
-
     private BasicSessionCredentials generateReaderSessionCredentials(String s3KeyName)
     {
         Policy policy = new Policy()
-        .withStatements(
-                new Statement(Effect.Allow)
-                .withActions(S3Actions.ListObjects)
-                .withResources(new Resource("arn:aws:s3:::"+s3BucketName)),
-                new Statement(Effect.Allow)
-                .withActions(S3Actions.GetObject)
-                .withResources(new Resource("arn:aws:s3:::"+s3BucketName+"/"+s3KeyName))  // TODO encode file name using percent encoding
-                );
+            .withStatements(
+                    new Statement(Effect.Allow)
+                        .withActions(S3Actions.ListObjects)
+                        .withResources(new Resource("arn:aws:s3:::"+s3BucketName)),
+                    new Statement(Effect.Allow)
+                        .withActions(S3Actions.GetObject)
+                        .withResources(new Resource("arn:aws:s3:::"+s3BucketName+"/"+s3KeyName))  // TODO encode file name using percent encoding
+                    );
         if (iamReaderUserName != null && iamReaderUserName.length() > 0) {
             GetFederationTokenRequest req = new GetFederationTokenRequest();
             req.setDurationSeconds(86400);  // 3600 - 129600
@@ -170,7 +165,7 @@ extends AbstractPostgreSQLCopyBatchInsert
 
         public Void call() throws SQLException {
             logger.info(String.format("Uploading file id %s to S3 (%,d bytes %,d rows)",
-                    s3KeyName, file.length(), batchRows));
+                        s3KeyName, file.length(), batchRows));
             s3.putObject(s3BucketName, s3KeyName, file);
 
             RedshiftOutputConnection con = connector.connect(true);

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
@@ -209,7 +209,6 @@ public class RedshiftCopyBatchInsert
             }
             sb.append("' ");
             sb.append(COPY_AFTER_FROM);
-//            System.err.println("Copy: " + sb.toString());
             return sb.toString();
         }
     }


### PR DESCRIPTION
The Redshift driver only supports "Federated" credentials, which simply means temporary S3 credentials. This requires an AWS user account and certain configurations. This is more complex than needed. I had two problems using it:
1) in my installation we use "headless" key pairs which do not include a user name, and
2) I could not get the plugin to work using my own personal account, even though I set all of the right permissions.
Note that the other plugins which access S3 only require access&secret keys. This is the only Embulk plugin that requires Federated credentials.

This PR allows the user to give AWS access&secret keys only. The 'iam_user_name' configuration entry can be left out, or have '' as its value.

Issue: https://github.com/embulk/embulk-output-jdbc/issues/85