### PR TITLE
Check not to close OCI twice

### DIFF
--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
@@ -42,7 +42,6 @@ public class DirectBatchInsert implements BatchInsert
     private long totalRows;
     private int rowSize;
     private int batchWeight;
-    private boolean closed;
 
     private DateFormat[] formats;
 
@@ -185,10 +184,7 @@ public class DirectBatchInsert implements BatchInsert
     @Override
     public void close() throws IOException, SQLException
     {
-        if (!closed) {
-            ociManager.close(ociKey);
-            closed = true;
-        }
+        ociManager.close(ociKey);
     }
 
     @Override

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
@@ -42,6 +42,7 @@ public class DirectBatchInsert implements BatchInsert
     private long totalRows;
     private int rowSize;
     private int batchWeight;
+    private boolean closed;
 
     private DateFormat[] formats;
 
@@ -184,7 +185,10 @@ public class DirectBatchInsert implements BatchInsert
     @Override
     public void close() throws IOException, SQLException
     {
-        ociManager.close(ociKey);
+        if (!closed) {
+            ociManager.close(ociKey);
+            closed = true;
+        }
     }
 
     @Override


### PR DESCRIPTION
The `DirectBatchInsert#close` method is called by the `PluginPageOutput#close` method.
The `PluginPageOutput#close` method seems to be called multiple times.
