### PR TITLE
Create on_duplicate_key_update option

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
@@ -134,6 +134,6 @@ public class JdbcOutputPlugin
     @Override
     protected BatchInsert newBatchInsert(PluginTask task, Optional<List<String>> mergeKeys) throws IOException, SQLException
     {
-        return new StandardBatchInsert(getConnector(task, true), mergeKeys);
+        return new StandardBatchInsert(getConnector(task, true), mergeKeys, task.getOnDuplicateKeyUpdate());
     }
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -91,6 +91,10 @@ public abstract class AbstractJdbcOutputPlugin
         @ConfigDefault("\"UTC\"")
         public DateTimeZone getDefaultTimeZone();
 
+        @Config("on_duplicate_key_update")
+        @ConfigDefault("null")
+        public Optional<String> getOnDuplicateKeyUpdate();
+
         public void setMergeKeys(Optional<List<String>> keys);
 
         public void setFeatures(Features features);
@@ -659,7 +663,7 @@ public abstract class AbstractJdbcOutputPlugin
             if (task.getNewTableSchema().isPresent()) {
                 con.createTableIfNotExists(task.getTable(), task.getNewTableSchema().get());
             }
-            con.collectMerge(task.getIntermediateTables().get(), schema, task.getTable(), task.getMergeKeys().get());
+            con.collectMerge(task.getIntermediateTables().get(), schema, task.getTable(), task.getMergeKeys().get(), task.getOnDuplicateKeyUpdate());
             break;
 
         case REPLACE:

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -238,11 +238,11 @@ public class JdbcOutputConnection
         return ColumnDeclareType.SIMPLE;
     }
 
-    public PreparedStatement prepareBatchInsertStatement(String toTable, JdbcSchema toTableSchema, Optional<List<String>> mergeKeys) throws SQLException
+    public PreparedStatement prepareBatchInsertStatement(String toTable, JdbcSchema toTableSchema, Optional<List<String>> mergeKeys, Optional<String> onDuplicateKeyUpdateSql) throws SQLException
     {
         String sql;
         if (mergeKeys.isPresent()) {
-            sql = buildPreparedMergeSql(toTable, toTableSchema, mergeKeys.get());
+            sql = buildPreparedMergeSql(toTable, toTableSchema, mergeKeys.get(), onDuplicateKeyUpdateSql);
         } else {
             sql = buildPreparedInsertSql(toTable, toTableSchema);
         }
@@ -272,7 +272,7 @@ public class JdbcOutputConnection
         return sb.toString();
     }
 
-    protected String buildPreparedMergeSql(String toTable, JdbcSchema toTableSchema, List<String> mergeKeys) throws SQLException
+    protected String buildPreparedMergeSql(String toTable, JdbcSchema toTableSchema, List<String> mergeKeys, Optional<String> onDuplicateKeyUpdateSql) throws SQLException
     {
         throw new UnsupportedOperationException("not implemented");
     }
@@ -332,11 +332,11 @@ public class JdbcOutputConnection
         return sb.toString();
     }
 
-    protected void collectMerge(List<String> fromTables, JdbcSchema schema, String toTable, List<String> mergeKeys) throws SQLException
+    protected void collectMerge(List<String> fromTables, JdbcSchema schema, String toTable, List<String> mergeKeys, Optional<String> onDuplicateKeyUpdateSql) throws SQLException
     {
         Statement stmt = connection.createStatement();
         try {
-            String sql = buildCollectMergeSql(fromTables, schema, toTable, mergeKeys);
+            String sql = buildCollectMergeSql(fromTables, schema, toTable, mergeKeys, onDuplicateKeyUpdateSql);
             executeUpdate(stmt, sql);
             commitIfNecessary(connection);
         } catch (SQLException ex) {
@@ -346,7 +346,7 @@ public class JdbcOutputConnection
         }
     }
 
-    protected String buildCollectMergeSql(List<String> fromTables, JdbcSchema schema, String toTable, List<String> mergeKeys) throws SQLException
+    protected String buildCollectMergeSql(List<String> fromTables, JdbcSchema schema, String toTable, List<String> mergeKeys, Optional<String> onDuplicateKeyUpdateSql) throws SQLException
     {
         throw new UnsupportedOperationException("not implemented");
     }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
@@ -20,6 +20,7 @@ public class StandardBatchInsert
 
     private final JdbcOutputConnector connector;
     private final Optional<List<String>> mergeKeys;
+    private final Optional<String> onDuplicateKeyUpdateSql;
 
     private JdbcOutputConnection connection;
     private PreparedStatement batch;
@@ -28,10 +29,11 @@ public class StandardBatchInsert
     private int batchRows;
     private long totalRows;
 
-    public StandardBatchInsert(JdbcOutputConnector connector, Optional<List<String>> mergeKeys) throws IOException, SQLException
+    public StandardBatchInsert(JdbcOutputConnector connector, Optional<List<String>> mergeKeys, Optional<String> onDuplicateKeyUpdateSql) throws IOException, SQLException
     {
         this.connector = connector;
         this.mergeKeys = mergeKeys;
+        this.onDuplicateKeyUpdateSql = onDuplicateKeyUpdateSql;
     }
 
     public void prepare(String loadTable, JdbcSchema insertSchema) throws SQLException
@@ -46,7 +48,7 @@ public class StandardBatchInsert
 
     protected PreparedStatement prepareStatement(String loadTable, JdbcSchema insertSchema) throws SQLException
     {
-        return connection.prepareBatchInsertStatement(loadTable, insertSchema, mergeKeys);
+        return connection.prepareBatchInsertStatement(loadTable, insertSchema, mergeKeys, onDuplicateKeyUpdateSql);
     }
 
     public int getBatchWeight()

--- a/embulk-output-mysql/README.md
+++ b/embulk-output-mysql/README.md
@@ -25,6 +25,7 @@ MySQL output plugins for Embulk loads records to MySQL.
   - **value_type**: This plugin converts input column type (embulk type) into a database type to build a INSERT statement. This value_type option controls the type of the value in a INSERT statement. (string, default: depends on the sql type of the column. Available values options are: `byte`, `short`, `int`, `long`, `double`, `float`, `boolean`, `string`, `nstring`, `date`, `time`, `timestamp`, `decimal`, `json`, `null`, `pass`)
   - **timestamp_format**: If input column type (embulk type) is timestamp and value_type is `string` or `nstring`, this plugin needs to format the timestamp value into a string. This timestamp_format option is used to control the format of the timestamp. (string, default: `%Y-%m-%d %H:%M:%S.%6N`)
   - **timezone**: If input column type (embulk type) is timestamp, this plugin needs to format the timestamp value into a SQL string. In this cases, this timezone option is used to control the timezone. (string, value of default_timezone option is used by default)
+- **on_duplicate_key_update**: SQL expression for `ON DUPLICATE KEY UPDATE` clause. Effective only for "merge", "merge_direct" modes (string, optional)
 
 ### Modes
 

--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
@@ -106,6 +106,6 @@ public class MySQLOutputPlugin
     @Override
     protected BatchInsert newBatchInsert(PluginTask task, Optional<List<String>> mergeKeys) throws IOException, SQLException
     {
-        return new MySQLBatchInsert(getConnector(task, true), mergeKeys);
+        return new MySQLBatchInsert(getConnector(task, true), mergeKeys, task.getOnDuplicateKeyUpdate());
     }
 }

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLBatchInsert.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLBatchInsert.java
@@ -10,9 +10,9 @@ import org.embulk.output.jdbc.StandardBatchInsert;
 public class MySQLBatchInsert
         extends StandardBatchInsert
 {
-    public MySQLBatchInsert(MySQLOutputConnector connector, Optional<List<String>> mergeKeys) throws IOException, SQLException
+    public MySQLBatchInsert(MySQLOutputConnector connector, Optional<List<String>> mergeKeys, Optional<String> onDuplicateKeyUpdateSql) throws IOException, SQLException
     {
-        super(connector, mergeKeys);
+        super(connector, mergeKeys, onDuplicateKeyUpdateSql);
     }
 
     @Override

--- a/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
@@ -154,6 +154,6 @@ public class OracleOutputPlugin
                     oracleTask.getBatchSize());
         }
 
-        return new StandardBatchInsert(getConnector(task, true), mergeKeys);
+        return new StandardBatchInsert(getConnector(task, true), mergeKeys, task.getOnDuplicateKeyUpdate());
     }
 }

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import com.google.common.base.Optional;
 import org.postgresql.copy.CopyManager;
 import org.postgresql.core.BaseConnection;
 import org.embulk.output.jdbc.JdbcOutputConnection;
@@ -43,7 +45,7 @@ public class PostgreSQLOutputConnection
     }
 
     @Override
-    protected String buildCollectMergeSql(List<String> fromTables, JdbcSchema schema, String toTable, List<String> mergeKeys) throws SQLException
+    protected String buildCollectMergeSql(List<String> fromTables, JdbcSchema schema, String toTable, List<String> mergeKeys, Optional<String> onDuplicateKeyUpdateSql) throws SQLException
     {
         StringBuilder sb = new StringBuilder();
 

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
@@ -158,7 +158,7 @@ public class SQLServerOutputPlugin
             return new NativeBatchInsert(sqlServerTask.getHost().get(), sqlServerTask.getPort(), sqlServerTask.getInstance(),
                     sqlServerTask.getDatabase().get(), sqlServerTask.getUser(), sqlServerTask.getPassword());
         }
-        return new StandardBatchInsert(getConnector(task, true), mergeKeys);
+        return new StandardBatchInsert(getConnector(task, true), mergeKeys, task.getOnDuplicateKeyUpdate());
     }
 
     @Override


### PR DESCRIPTION
In order to control overwrite behavior of merge_direct method, add functionality to set `ON DUPLICATE KEY UPDATE`.

@joker1007 review me.