### PR TITLE
Exception for duplicate keys in Oracle OCI

### DIFF
--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
@@ -153,19 +153,11 @@ public class DirectBatchInsert implements BatchInsert
             rowSize += column.getDataSize();
         }
 
-        TableDefinition tableDefinition = new TableDefinition(quoteIdentifierString(schema), quoteIdentifierString(loadTable), columns);
+        TableDefinition tableDefinition = new TableDefinition(schema, loadTable, columns);
         ociKey = Arrays.asList(database, user, loadTable);
         ociManager.open(ociKey, database, user, password, tableDefinition);
 
         buffer = new RowBuffer(tableDefinition, Math.max(batchSize / rowSize, 8));
-    }
-
-    private String quoteIdentifierString(String s)
-    {
-        if (s == null) {
-            return null;
-        }
-        return "\"" + s + "\"";
     }
 
     @Override

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCI.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCI.java
@@ -15,18 +15,12 @@ public interface OCI
     static short OCI_NO_DATA = 100;
     static short OCI_CONTINUE = -24200;
 
-    static short OCI_DEFAULT = 0;
-    static int OCI_NTV_SYNTAX = 1;
-
     static int OCI_THREADED = 1;
     static int OCI_OBJECT = 2;
 
     static int OCI_HTYPE_ENV = 1;
     static int OCI_HTYPE_ERROR = 2;
     static int OCI_HTYPE_SVCCTX = 3;
-    static int OCI_HTYPE_STMT = 4;
-    static int OCI_HTYPE_BIND = 5;
-    static int OCI_HTYPE_DEFINE = 6;
     static int OCI_HTYPE_DIRPATH_CTX = 14;
     static int OCI_HTYPE_DIRPATH_COLUMN_ARRAY = 15;
     static int OCI_HTYPE_DIRPATH_STREAM = 16;
@@ -41,6 +35,7 @@ public interface OCI
     static int OCI_ATTR_NUM_ROWS = 81;
     static int OCI_ATTR_NUM_COLS = 102;
     static int OCI_ATTR_LIST_COLUMNS = 103;
+    static int OCI_ATTR_DIRPATH_NO_INDEX_ERRORS = 2013;
 
     static int OCI_DTYPE_PARAM = 53;
 
@@ -134,54 +129,4 @@ public interface OCI
     short OCIDirPathFinish(Pointer dpctx, Pointer errhp);
 
     short OCIDirPathAbort(Pointer dpctx, Pointer errhp);
-
-    short OCIStmtPrepare(Pointer stmtp,
-            Pointer errhp,
-            String stmt,
-            @u_int32_t int stmtLen,
-            @u_int32_t int languate,
-            @u_int32_t int mode);
-
-    short OCIBindByName(Pointer stmtp,
-            Pointer bindpp,
-            Pointer errhp,
-            String placeholder,
-            int placehLen,
-            Pointer valuep,
-            int valueSz,
-            @u_int16_t short dty,
-            Pointer indp,
-            Pointer alenp,
-            Pointer rcodep,
-            @u_int32_t int maxarrLen,
-            Pointer curelep,
-            @u_int32_t int mode);
-
-    short OCIStmtExecute(Pointer svchp,
-            Pointer stmtp,
-            Pointer errhp,
-            @u_int32_t int iters,
-            @u_int32_t int rowoff,
-            Pointer snapIn,
-            Pointer snapOut,
-            @u_int32_t int mode);
-
-    short OCIDefineByPos(Pointer stmtp,
-            Pointer defnpp,
-            Pointer errhp,
-            @u_int32_t int position,
-            Pointer valuep,
-            int valueSz,
-            @u_int16_t short dty,
-            Pointer indp,
-            Pointer rlenp,
-            Pointer rcodep,
-            @u_int32_t int mode);
-
-    short OCIStmtFetch2(Pointer stmthp,
-            Pointer errhp,
-            @u_int32_t int nrows,
-            @u_int16_t short orientation,
-            int fetchOffset,
-            @u_int32_t int mode);
  }

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCI.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCI.java
@@ -15,6 +15,8 @@ public interface OCI
     static short OCI_NO_DATA = 100;
     static short OCI_CONTINUE = -24200;
 
+    static short OCI_DEFAULT = 0;
+    static int OCI_NTV_SYNTAX = 1;
 
     static int OCI_THREADED = 1;
     static int OCI_OBJECT = 2;
@@ -22,6 +24,8 @@ public interface OCI
     static int OCI_HTYPE_ENV = 1;
     static int OCI_HTYPE_ERROR = 2;
     static int OCI_HTYPE_SVCCTX = 3;
+    static int OCI_HTYPE_STMT = 4;
+    static int OCI_HTYPE_DEFINE = 6;
     static int OCI_HTYPE_DIRPATH_CTX = 14;
     static int OCI_HTYPE_DIRPATH_COLUMN_ARRAY = 15;
     static int OCI_HTYPE_DIRPATH_STREAM = 16;
@@ -41,8 +45,8 @@ public interface OCI
 
     static byte OCI_DIRPATH_COL_COMPLETE = 0;
 
-    static int SQLT_CHR = 1;
-    static int SQLT_INT = 3;
+    static short SQLT_CHR = 1;
+    static short SQLT_INT = 3;
 
     short OCIErrorGet(Pointer hndlp,
             @u_int32_t int  recordno,
@@ -129,4 +133,39 @@ public interface OCI
     short OCIDirPathFinish(Pointer dpctx, Pointer errhp);
 
     short OCIDirPathAbort(Pointer dpctx, Pointer errhp);
-}
+
+    short OCIStmtPrepare(Pointer stmtp,
+            Pointer errhp,
+            String stmt,
+            @u_int32_t int stmtLen,
+            @u_int32_t int languate,
+            @u_int32_t int mode);
+
+    short OCIStmtExecute(Pointer svchp,
+            Pointer stmtp,
+            Pointer errhp,
+            @u_int32_t int iters,
+            @u_int32_t int rowoff,
+            Pointer snapIn,
+            Pointer snapOut,
+            @u_int32_t int mode);
+
+    short OCIDefineByPos(Pointer stmtp,
+            Pointer defnpp,
+            Pointer errhp,
+            @u_int32_t int position,
+            Pointer valuep,
+            int valueSz,
+            @u_int16_t short dty,
+            Pointer indp,
+            Pointer rlenp,
+            Pointer rcodep,
+            @u_int32_t int mode);
+
+    short OCIStmtFetch2(Pointer stmthp,
+            Pointer errhp,
+            @u_int32_t int nrows,
+            @u_int16_t short orientation,
+            int fetchOffset,
+            @u_int32_t int mode);
+ }

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCI.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCI.java
@@ -25,6 +25,7 @@ public interface OCI
     static int OCI_HTYPE_ERROR = 2;
     static int OCI_HTYPE_SVCCTX = 3;
     static int OCI_HTYPE_STMT = 4;
+    static int OCI_HTYPE_BIND = 5;
     static int OCI_HTYPE_DEFINE = 6;
     static int OCI_HTYPE_DIRPATH_CTX = 14;
     static int OCI_HTYPE_DIRPATH_COLUMN_ARRAY = 15;
@@ -139,6 +140,21 @@ public interface OCI
             String stmt,
             @u_int32_t int stmtLen,
             @u_int32_t int languate,
+            @u_int32_t int mode);
+
+    short OCIBindByName(Pointer stmtp,
+            Pointer bindpp,
+            Pointer errhp,
+            String placeholder,
+            int placehLen,
+            Pointer valuep,
+            int valueSz,
+            @u_int16_t short dty,
+            Pointer indp,
+            Pointer alenp,
+            Pointer rcodep,
+            @u_int32_t int maxarrLen,
+            Pointer curelep,
             @u_int32_t int mode);
 
     short OCIStmtExecute(Pointer svchp,

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIManager.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIManager.java
@@ -54,8 +54,8 @@ public class OCIManager
                 ociAndCounter.counter--;
                 if (ociAndCounter.counter == 0) {
                     logger.info(String.format("OCI : close for %s.", key));
-                    ociAndCounter.oci.close();
                     ociAndCounters.remove(key);
+                    ociAndCounter.oci.close();
                 }
             }
         }

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
@@ -376,6 +376,7 @@ public class OCIWrapper
                 null));
         stmtHandle = stmtHandlePointer.getPointer(0);
 
+        // doesn't work for multibyte table name...
         String placeHolder = "tableName";
         String sql = "SELECT INDEX_NAME, STATUS FROM USER_INDEXES WHERE TABLE_NAME=:" + placeHolder;
         check("OCIStmtPrepare(" + sql + ")", oci.OCIStmtPrepare(

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/OCIWrapper.java
@@ -26,7 +26,6 @@ public class OCIWrapper
     private final Charset systemCharset;
     private Pointer envHandle;
     private Pointer errHandle;
-    private Pointer svcHandlePointer;
     private Pointer svcHandle;
     private Pointer dpHandle;
     private Pointer dpcaHandle;
@@ -98,7 +97,7 @@ public class OCIWrapper
         errHandle = errHandlePointer.getPointer(0);
 
         // service context
-        svcHandlePointer = createPointerPointer();
+        Pointer svcHandlePointer = createPointerPointer();
         check("OCIHandleAlloc(OCI_HTYPE_SVCCTX)", oci.OCIHandleAlloc(
                 envHandle,
                 svcHandlePointer,

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/RowBuffer.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/oci/RowBuffer.java
@@ -70,8 +70,8 @@ public class RowBuffer
 
         ByteBuffer bytes = charset.encode(value);
         int length = bytes.remaining();
-        if (length > 65535) {
-            throw new SQLException(String.format("byte count of string is too large (max : 65535, actual : %d).", length));
+        if (length > Short.MAX_VALUE) {
+            throw new SQLException(String.format("byte count of string is too large (max : %d, actual : %d).", Short.MAX_VALUE, length));
         }
         if (length > column.getDataSize()) {
             throw new SQLException(String.format("byte count of string is too large for column \"%s\" (max : %d, actual : %d).",

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTest.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTest.java
@@ -212,6 +212,18 @@ public class OracleOutputPluginTest
     }
 
     @Test
+    public void testInsertDirectOCIMethodMultibyte() throws Exception
+    {
+        invoke(test12c, "testInsertDirectOCIMethodMultibyte");
+    }
+
+    @Test
+    public void testInsertDirectOCIMethodMultibyteDuplicate() throws Exception
+    {
+        invoke(test12c, "testInsertDirectOCIMethodMultibyteDuplicate");
+    }
+
+    @Test
     public void testInsertDirectOCIMethodSplit() throws Exception
     {
         invoke(test12c, "testInsertDirectOCIMethodSplit");

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTest.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTest.java
@@ -176,6 +176,12 @@ public class OracleOutputPluginTest
     }
 
     @Test
+    public void testInsertDirectDuplicate() throws Exception
+    {
+        invoke(test12c, "testInsertDirectDuplicate");
+    }
+
+    @Test
     public void testInsertDirectCreate() throws Exception
     {
         invoke("testInsertDirectCreate");
@@ -197,6 +203,12 @@ public class OracleOutputPluginTest
     public void testInsertDirectOCIMethod() throws Exception
     {
         invoke(test12c, "testInsertDirectOCIMethod");
+    }
+
+    @Test
+    public void testInsertDirectOCIMethodDuplicate() throws Exception
+    {
+        invoke(test12c, "testInsertDirectOCIMethodDuplicate");
     }
 
     @Test

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
@@ -218,6 +218,7 @@ public class OracleOutputPluginTestImpl extends AbstractJdbcOutputPluginTest
 
         dropTable(table);
         createTable(table);
+        insertRecord(table, "A002");
 
         try {
             run("/oracle/yml/test-insert-direct-oci-method.yml");

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
@@ -228,6 +228,34 @@ public class OracleOutputPluginTestImpl extends AbstractJdbcOutputPluginTest
         }
     }
 
+    public void testInsertDirectOCIMethodMultibyte() throws Exception
+    {
+        String table = "ＴＥＳＴ１";
+
+        dropTable(table);
+        createTable(table);
+
+        run("/oracle/yml/test-insert-direct-oci-method-multibyte.yml");
+
+        assertTable(table);
+    }
+
+    public void testInsertDirectOCIMethodMultibyteDuplicate() throws Exception
+    {
+        String table = "ＴＥＳＴ１";
+
+        dropTable(table);
+        createTable(table);
+        insertRecord(table, "A002");
+
+        try {
+            run("/oracle/yml/test-insert-direct-oci-method-multibyte.yml");
+            fail("Exception expected.");
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+    }
+
     public void testInsertDirectOCIMethodSplit() throws Exception
     {
         String table = "TEST1";

--- a/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
+++ b/embulk-output-oracle/src/test/java/org/embulk/output/oracle/OracleOutputPluginTestImpl.java
@@ -1,6 +1,7 @@
 package org.embulk.output.oracle;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -147,6 +148,22 @@ public class OracleOutputPluginTestImpl extends AbstractJdbcOutputPluginTest
         assertTable(table);
     }
 
+    public void testInsertDirectDuplicate() throws Exception
+    {
+        String table = "TEST1";
+
+        dropTable(table);
+        createTable(table);
+        insertRecord(table, "A002");
+
+        try {
+            run("/oracle/yml/test-insert-direct.yml");
+            fail("Exception expected.");
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+    }
+
     public void testInsertDirectEmpty() throws Exception
     {
         String table = "TEST1";
@@ -193,6 +210,21 @@ public class OracleOutputPluginTestImpl extends AbstractJdbcOutputPluginTest
         run("/oracle/yml/test-insert-direct-oci-method.yml");
 
         assertTable(table);
+    }
+
+    public void testInsertDirectOCIMethodDuplicate() throws Exception
+    {
+        String table = "TEST1";
+
+        dropTable(table);
+        createTable(table);
+
+        try {
+            run("/oracle/yml/test-insert-direct-oci-method.yml");
+            fail("Exception expected.");
+        } catch (Exception e) {
+            System.out.println(e);
+        }
     }
 
     public void testInsertDirectOCIMethodSplit() throws Exception
@@ -316,7 +348,12 @@ public class OracleOutputPluginTestImpl extends AbstractJdbcOutputPluginTest
 
     private void insertRecord(String table) throws SQLException
     {
-        executeSQL(String.format("INSERT INTO %s VALUES('9999', NULL, NULL, NULL, NULL, NULL, NULL)", table));
+        insertRecord(table, "9999");
+    }
+
+    private void insertRecord(String table, String id) throws SQLException
+    {
+        executeSQL(String.format("INSERT INTO %s VALUES('%s', NULL, NULL, NULL, NULL, NULL, NULL)", table, id));
     }
 
     private void assertTable(String table) throws Exception

--- a/embulk-output-oracle/src/test/resources/oracle/yml/test-insert-direct-oci-method-multibyte.yml
+++ b/embulk-output-oracle/src/test/resources/oracle/yml/test-insert-direct-oci-method-multibyte.yml
@@ -1,0 +1,29 @@
+in:
+  type: file
+  path_prefix: '/oracle/data/test1/test1.csv'
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: ''
+    columns:
+    - {name: ID, type: string}
+    - {name: VARCHAR2_ITEM, type: string}
+    - {name: NVARCHAR2_ITEM, type: string}
+    - {name: INTEGER_ITEM, type: long}
+    - {name: NUMBER_ITEM, type: string}
+    - {name: DATE_ITEM, type: timestamp, format: '%Y/%m/%d'}
+    - {name: TIMESTAMP_ITEM, type: timestamp, format: '%Y/%m/%d %H:%M:%S'}
+out:
+    type: oracle
+    host: localhost
+    database: TESTDB
+    user: TEST_USER
+    password: test_pw
+    table: ＴＥＳＴ１
+    mode: insert_direct
+    insert_method: oci
+    column_options:
+      INTEGER_ITEM: {value_type: pass}
+    #driver_path: driver/ojdbc7.jar


### PR DESCRIPTION
If keys already exist when loading records by Oracle OCI, the index becomes unusable but no exception is thrown.
We should check if index is usable and throw an exception.