### PR TITLE
Implements retryable execution feature

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -1,5 +1,6 @@
 package org.embulk.output.jdbc;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +91,14 @@ public abstract class AbstractJdbcOutputPlugin
         @Config("default_timezone")
         @ConfigDefault("\"UTC\"")
         public DateTimeZone getDefaultTimeZone();
+
+        @Config("retry_limit")
+        @ConfigDefault("0")
+        public int getRetryLimit();
+
+        @Config("retry_wait")
+        @ConfigDefault("5")
+        public int getRetryWait();
 
         public void setActualTable(String actualTable);
         public String getActualTable();
@@ -646,14 +655,16 @@ public abstract class AbstractJdbcOutputPlugin
         return lengthSemantics.countLength(tableNameCharset, tableName) + suffixLength <= maxLength;
     }
 
-    protected void doCommit(JdbcOutputConnection con, PluginTask task, int taskCount)
+    protected void doCommit(final JdbcOutputConnection con, final PluginTask task, int taskCount)
         throws SQLException
     {
         if (task.getIntermediateTables().get().isEmpty()) {
             return;
         }
 
-        JdbcSchema schema = filterSkipColumns(task.getTargetTableSchema());
+        RetryableSQLExecutor executor = new RetryableSQLExecutor(retryableErrorStates(), retryableErrorCodes(), task.getRetryLimit(), task.getRetryWait());
+
+        final JdbcSchema schema = filterSkipColumns(task.getTargetTableSchema());
 
         switch (task.getMode()) {
         case INSERT_DIRECT:
@@ -682,7 +693,12 @@ public abstract class AbstractJdbcOutputPlugin
             if (task.getNewTableSchema().isPresent()) {
                 con.createTableIfNotExists(task.getActualTable(), task.getNewTableSchema().get());
             }
-            con.collectMerge(task.getIntermediateTables().get(), schema, task.getActualTable(), task.getMergeKeys().get());
+            executor.retryableStmtExecute(new RetryableSQLExecution() {
+                @Override
+                public void run() throws SQLException {
+                  con.collectMerge(task.getIntermediateTables().get(), schema, task.getActualTable(), task.getMergeKeys().get());
+                }
+            });
             break;
 
         case REPLACE:
@@ -861,7 +877,7 @@ public abstract class AbstractJdbcOutputPlugin
             }
             batch.prepare(destTable, insertIntoSchema);
 
-            PluginPageOutput output = new PluginPageOutput(reader, batch, columnSetters, task.getBatchSize());
+            PluginPageOutput output = new PluginPageOutput(reader, batch, columnSetters, task.getBatchSize(), retryableErrorStates(), retryableErrorCodes(), task.getRetryLimit(), task.getRetryWait());
             batch = null;
             return output;
 
@@ -888,10 +904,11 @@ public abstract class AbstractJdbcOutputPlugin
         private final BatchInsert batch;
         private final int batchSize;
         private final int forceBatchFlushSize;
+        private final RetryableSQLExecutor executor;
 
         public PluginPageOutput(final PageReader pageReader,
                 BatchInsert batch, List<ColumnSetter> columnSetters,
-                int batchSize)
+                int batchSize, String[] retryableErrorStates, Integer[] retryableErrorCodes, int retryLimit, int retryWait)
         {
             this.pageReader = pageReader;
             this.batch = batch;
@@ -904,6 +921,7 @@ public abstract class AbstractJdbcOutputPlugin
                             }
                         }));
             this.batchSize = batchSize;
+            this.executor = new RetryableSQLExecutor(retryableErrorStates, retryableErrorCodes, retryLimit, retryWait);
             this.forceBatchFlushSize = batchSize * 2;
         }
 
@@ -914,13 +932,31 @@ public abstract class AbstractJdbcOutputPlugin
                 pageReader.setPage(page);
                 while (pageReader.nextRecord()) {
                     if (batch.getBatchWeight() > forceBatchFlushSize) {
-                        batch.flush();
+                        executor.retryableStmtExecute(new RetryableSQLExecution() {
+                            @Override
+                            public void run() throws SQLException {
+                                try {
+                                    batch.flush();
+                                } catch (IOException ex) {
+                                    throw new RuntimeException(ex);
+                                }
+                            }
+                        });
                     }
                     handleColumnsSetters();
                     batch.add();
                 }
                 if (batch.getBatchWeight() > batchSize) {
-                    batch.flush();
+                    executor.retryableStmtExecute(new RetryableSQLExecution() {
+                        @Override
+                        public void run() throws SQLException {
+                            try {
+                                batch.flush();
+                            } catch (IOException ex) {
+                                throw new RuntimeException(ex);
+                            }
+                        }
+                    });
                 }
             } catch (IOException | SQLException ex) {
                 throw new RuntimeException(ex);
@@ -1061,4 +1097,59 @@ public abstract class AbstractJdbcOutputPlugin
         }
         buildExceptionMessageCont(sb, ex.getCause(), ex.getMessage());
     }
+
+    protected String[] retryableErrorStates() {
+        return new String[]{};
+    }
+
+    protected Integer[] retryableErrorCodes() {
+        return new Integer[]{};
+    }
+
+    interface RetryableSQLExecution {
+        void run() throws SQLException;
+    }
+
+    static class RetryableSQLExecutor {
+        private final String[] retryableErrorStates;
+        private final Integer[] retryableErrorCodes;
+        private final int retryLimit;
+        private final int retryWait;
+
+        RetryableSQLExecutor(String[] retryableErrorStates, Integer[] retryableErrorCodes, int retryLimit, int retryWait) {
+            this.retryableErrorStates = retryableErrorStates;
+            this.retryableErrorCodes = retryableErrorCodes;
+            this.retryLimit = retryLimit;
+            this.retryWait = retryWait;
+        }
+
+        public void retryableStmtExecute(RetryableSQLExecution process)
+                throws SQLException
+        {
+            int retryCount = 0;
+            while (true) {
+                try {
+                    process.run();
+                    break;
+                } catch (SQLException ex) {
+                    List<String> states = Arrays.asList(retryableErrorStates);
+                    List<Integer> codes = Arrays.asList(retryableErrorCodes);
+
+                    if (states.contains(ex.getSQLState()) || codes.contains(ex.getErrorCode())) {
+                        retryCount++;
+                        if (retryCount > retryLimit)
+                            throw ex;
+
+                        try {
+                            Thread.sleep(retryWait * 1000);
+                        } catch (InterruptedException ignored) {
+                        }
+                    } else {
+                        throw ex;
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -696,16 +696,7 @@ public abstract class AbstractJdbcOutputPlugin
             if (task.getNewTableSchema().isPresent()) {
                 con.createTableIfNotExists(task.getActualTable(), task.getNewTableSchema().get());
             }
-            try {
-                withRetry(task, retryableErrorStates(), retryableErrorCodes(), new IdempotentSqlRunnable() {
-                    @Override
-                    public void run() throws SQLException {
-                        con.collectMerge(task.getIntermediateTables().get(), schema, task.getActualTable(), task.getMergeKeys().get());
-                    }
-                });
-            } catch (InterruptedException ex) {
-                throw new RuntimeException(ex);
-            }
+            con.collectMerge(task.getIntermediateTables().get(), schema, task.getActualTable(), task.getMergeKeys().get());
             break;
 
         case REPLACE:

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -1027,13 +1027,13 @@ public abstract class AbstractJdbcOutputPlugin
         public void run() throws SQLException;
     }
 
-    private static void withRetry(PluginTask task, String[] retryableErrorStates, Integer[] retryableErrorCodes, IdempotentSqlRunnable op)
+    protected static void withRetry(PluginTask task, String[] retryableErrorStates, Integer[] retryableErrorCodes, IdempotentSqlRunnable op)
             throws SQLException, InterruptedException
     {
         withRetry(task, retryableErrorStates, retryableErrorCodes, op, "Operation failed");
     }
 
-    private static void withRetry(PluginTask task, String[] retryableErrorStates, Integer[] retryableErrorCodes, final IdempotentSqlRunnable op, final String errorMessage)
+    protected static void withRetry(PluginTask task, String[] retryableErrorStates, Integer[] retryableErrorCodes, final IdempotentSqlRunnable op, final String errorMessage)
             throws SQLException, InterruptedException
     {
         try {

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -659,14 +659,14 @@ public abstract class AbstractJdbcOutputPlugin
         return lengthSemantics.countLength(tableNameCharset, tableName) + suffixLength <= maxLength;
     }
 
-    protected void doCommit(final JdbcOutputConnection con, final PluginTask task, int taskCount)
+    protected void doCommit(JdbcOutputConnection con, PluginTask task, int taskCount)
         throws SQLException
     {
         if (task.getIntermediateTables().get().isEmpty()) {
             return;
         }
 
-        final JdbcSchema schema = filterSkipColumns(task.getTargetTableSchema());
+        JdbcSchema schema = filterSkipColumns(task.getTargetTableSchema());
 
         switch (task.getMode()) {
         case INSERT_DIRECT:

--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
@@ -114,9 +114,9 @@ public class MySQLOutputPlugin
     protected boolean isRetryableException(String sqlState, int errorCode)
     {
         switch (errorCode) {
-            case 1213:
+            case 1213: // ER_LOCK_DEADLOCK (Message: Deadlock found when trying to get lock; try restarting transaction)
                 return true;
-            case 1205:
+            case 1205: // ER_LOCK_WAIT_TIMEOUT (Message: Lock wait timeout exceeded; try restarting transaction)
                 return true;
             default:
                 return false;

--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
@@ -108,4 +108,14 @@ public class MySQLOutputPlugin
     {
         return new MySQLBatchInsert(getConnector(task, true), mergeKeys);
     }
+
+    @Override
+    protected String[] retryableErrorStates() {
+        return new String[]{"40001"};
+    }
+
+    @Override
+    protected Integer[] retryableErrorCodes() {
+        return new Integer[]{1213, 1205};
+    }
 }

--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
@@ -109,13 +109,17 @@ public class MySQLOutputPlugin
         return new MySQLBatchInsert(getConnector(task, true), mergeKeys);
     }
 
-    @Override
-    protected String[] retryableErrorStates() {
-        return new String[]{"40001"};
-    }
 
     @Override
-    protected Integer[] retryableErrorCodes() {
-        return new Integer[]{1213, 1205};
+    protected boolean isRetryableException(String sqlState, int errorCode)
+    {
+        switch (errorCode) {
+            case 1213:
+                return true;
+            case 1205:
+                return true;
+            default:
+                return false;
+        }
     }
 }


### PR DESCRIPTION
Some insert errors are retryable.
For example, I use MySQL and multi threaded embulk-output-mysql, deadlock error occurs often.
If plugin can retry transaction, plugin can continue to process.

I think that such situation occurs only when `mode` is `merge_direct` or `merge` (maybe only MySQL).
But I am in trouble.