### PR TITLE
Default value for SSL should be escaped

### DIFF
--- a/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
@@ -67,7 +67,7 @@ public class RedshiftOutputPlugin
         public String getS3KeyPrefix();
 
         @Config("ssl")
-        @ConfigDefault("disable")
+        @ConfigDefault("\"disable\"")
         public Ssl getSsl();
     }
 


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/embulk/embulk-output-jdbc/pull/117.

Without escaping, this gives the following error:

```
Error: org.embulk.config.ConfigException: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'disable': was expecting ('true', 'false' or 'null')
```

output to Redshift is currently broken on master due to this if someones doesn't put `ssl` in the configuration section