### PR TITLE
Fix NullPointerException in StandardBatchInsert#close

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -758,8 +758,11 @@ public abstract class AbstractJdbcOutputPlugin
                             4000, 0, false, false));  // TODO size type param
                 }
 
-                public void jsonColumn(Column column) {
-                    throw new UnsupportedOperationException("This plugin doesn't support json type. Please try to upgrade version of the plugin using 'embulk gem update' command. If the latest version still doesn't support json type, please contact plugin developers, or change configuration of input plugin not to use json type.");
+                public void jsonColumn(Column column)
+                {
+                    columns.add(JdbcColumn.newGenericTypeColumn(
+                            columnName, Types.CLOB, "CLOB",
+                            4000, 0, false, false));  // TODO size type param
                 }
 
                 public void timestampColumn(Column column)

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -758,11 +758,8 @@ public abstract class AbstractJdbcOutputPlugin
                             4000, 0, false, false));  // TODO size type param
                 }
 
-                public void jsonColumn(Column column)
-                {
-                    columns.add(JdbcColumn.newGenericTypeColumn(
-                            columnName, Types.CLOB, "CLOB",
-                            4000, 0, false, false));  // TODO size type param
+                public void jsonColumn(Column column) {
+                    throw new UnsupportedOperationException("This plugin doesn't support json type. Please try to upgrade version of the plugin using 'embulk gem update' command. If the latest version still doesn't support json type, please contact plugin developers, or change configuration of input plugin not to use json type.");
                 }
 
                 public void timestampColumn(Column column)

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
@@ -1,6 +1,5 @@
 package org.embulk.output.jdbc;
 
-import java.util.List;
 import java.util.Calendar;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -64,7 +63,9 @@ public class StandardBatchInsert
 
     public void close() throws IOException, SQLException
     {
-        connection.close();
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     public void flush() throws IOException, SQLException


### PR DESCRIPTION
If `StandardBatchInsert#close` is called before `prepare`, NullPointerException will be thrown.