### PR TITLE
merge_direct fixes for postgresql 

### DIFF
--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -52,9 +52,10 @@ public class PostgreSQLOutputConnection
         sb.append("WITH S AS (");
         sb.append("SELECT ");
         for (int i = 0; i < schema.getCount(); i++) {
+            JdbcColumn column = schema.getColumn(i);
             if (i != 0) { sb.append(", "); }
-            sb.append("? AS ");
-            quoteIdentifierString(sb, schema.getColumnName(i));
+            sb.append("CAST(? AS " + column.getSimpleTypeName() + ") AS ");
+            quoteIdentifierString(sb, column.getName());
         }
         sb.append("),");
         sb.append("updated AS (");


### PR DESCRIPTION
With certain datatypes (timestamp, bigint, uuid...) direct merge fails, because postgres doesnt how to work with the data given in the `WITH S AS` select
`ERROR: XX000: failed to find conversion function from unknown to ...`

This patch does cast on all the values.
