### PR TITLE
Upgrade aws-java-sdk libraries version for supporting newer region.

### DIFF
--- a/embulk-output-redshift/build.gradle
+++ b/embulk-output-redshift/build.gradle
@@ -2,8 +2,8 @@ dependencies {
     compile project(':embulk-output-jdbc')
     compile project(':embulk-output-postgresql')
 
-    compile "com.amazonaws:aws-java-sdk-s3:1.10.33"
-    compile "com.amazonaws:aws-java-sdk-sts:1.10.33"
+    compile "com.amazonaws:aws-java-sdk-s3:1.10.77"
+    compile "com.amazonaws:aws-java-sdk-sts:1.10.77"
 	compile 'org.embulk.input.s3:embulk-util-aws-credentials:0.2.8'
 
     testCompile project(':embulk-output-jdbc').sourceSets.test.output


### PR DESCRIPTION
With current sdk version, error raised with that message.

`Error: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: Cannot create enum from ap-northeast-2 value!`