### PR TITLE
Fix intermediate table duplication

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -15,6 +15,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import org.embulk.spi.util.RetryExecutor;
+import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 import org.slf4j.Logger;
 import org.joda.time.DateTimeZone;
 
@@ -491,28 +492,10 @@ public abstract class AbstractJdbcOutputPlugin
 
         // create intermediate tables
         if (!mode.isDirectModify()) {
-            // direct modify mode doesn't need intermediate tables.
-            ImmutableList.Builder<String> intermTableNames = ImmutableList.builder();
-            if (mode.tempTablePerTask()) {
-                String namePrefix = generateIntermediateTableNamePrefix(task.getActualTable(), con, 3,
-                        task.getFeatures().getMaxTableNameLength(), task.getFeatures().getTableNameLengthSemantics());
-                for (int i = 0; i < taskCount; i++) {
-                    intermTableNames.add(namePrefix + String.format("%03d", i));
-                }
-            } else {
-                String name = generateIntermediateTableNamePrefix(task.getActualTable(), con, 0,
-                        task.getFeatures().getMaxTableNameLength(), task.getFeatures().getTableNameLengthSemantics());
-                intermTableNames.add(name);
-            }
             // create the intermediate tables here
-            task.setIntermediateTables(Optional.<List<String>>of(intermTableNames.build()));
-            for (String name : task.getIntermediateTables().get()) {
-                // DROP TABLE IF EXISTS xyz__0000000054d92dee1e452158_bulk_load_temp
-                con.dropTableIfExists(name);
-                // CREATE TABLE IF NOT EXISTS xyz__0000000054d92dee1e452158_bulk_load_temp
-                con.createTableIfNotExists(name, newTableSchema);
-            }
+            task.setIntermediateTables(Optional.<List<String>>of(createIntermediateTables(con, task, taskCount, newTableSchema)));
         } else {
+            // direct modify mode doesn't need intermediate tables.
             task.setIntermediateTables(Optional.<List<String>>absent());
         }
 
@@ -578,6 +561,76 @@ public abstract class AbstractJdbcOutputPlugin
     protected ColumnSetterFactory newColumnSetterFactory(BatchInsert batch, DateTimeZone defaultTimeZone)
     {
         return new ColumnSetterFactory(batch, defaultTimeZone);
+    }
+
+    private List<String> createIntermediateTables(final JdbcOutputConnection con,
+            final PluginTask task, final int taskCount, final JdbcSchema newTableSchema) throws SQLException
+    {
+        try {
+            return buildRetryExecutor(task).run(new Retryable<List<String>>() {
+                private ImmutableList.Builder<String> intermTableNames;
+
+                @Override
+                public List<String> call() throws Exception
+                {
+                    intermTableNames = ImmutableList.builder();
+                    if (task.getMode().tempTablePerTask()) {
+                        String namePrefix = generateIntermediateTableNamePrefix(task.getActualTable(), con, 3,
+                                task.getFeatures().getMaxTableNameLength(), task.getFeatures().getTableNameLengthSemantics());
+                        for (int taskIndex = 0; taskIndex < taskCount; taskIndex++) {
+                            String name = namePrefix + String.format("%03d", taskIndex);
+                            // if table already exists, SQLException will be thrown
+                            con.createTable(name, newTableSchema);
+                            intermTableNames.add(name);
+                        }
+                    } else {
+                        String name = generateIntermediateTableNamePrefix(task.getActualTable(), con, 0,
+                                task.getFeatures().getMaxTableNameLength(), task.getFeatures().getTableNameLengthSemantics());
+                        con.createTable(name, newTableSchema);
+                        intermTableNames.add(name);
+                    }
+                    return intermTableNames.build();
+                }
+
+                @Override
+                public boolean isRetryableException(Exception exception)
+                {
+                    return exception instanceof SQLException;
+                }
+
+                @Override
+                public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                        throws RetryGiveupException
+                {
+                    logger.info("Try to create intermediate tables again because already exist");
+                    try {
+                        dropTables();
+                    } catch (SQLException e) {
+                        throw new RetryGiveupException(e);
+                    }
+                }
+
+                @Override
+                public void onGiveup(Exception firstException, Exception lastException)
+                        throws RetryGiveupException
+                {
+                    try {
+                        dropTables();
+                    } catch (SQLException e) {
+                        logger.warn("Cannot delete intermediate table", e);
+                    }
+                }
+
+                private void dropTables() throws SQLException
+                {
+                    for (String name : intermTableNames.build()) {
+                        con.dropTableIfExists(name);
+                    }
+                }
+            });
+        } catch (RetryGiveupException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected String generateIntermediateTableNamePrefix(String baseTableName, JdbcOutputConnection con,

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
@@ -83,30 +83,6 @@ public class OracleOutputConnection
         }
     }
 
-    public void createTable(String tableName, JdbcSchema schema) throws SQLException
-    {
-        Statement stmt = connection.createStatement();
-        try {
-            String sql = buildCreateTableSql(tableName, schema);
-            executeUpdate(stmt, sql);
-            commitIfNecessary(connection);
-        } catch (SQLException ex) {
-            throw safeRollback(connection, ex);
-        } finally {
-            stmt.close();
-        }
-    }
-
-    protected String buildCreateTableSql(String name, JdbcSchema schema)
-    {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("CREATE TABLE ");
-        quoteIdentifierString(sb, name);
-        sb.append(buildCreateTableSchemaSql(schema));
-        return sb.toString();
-    }
-
     private static String getSchema(Connection connection) throws SQLException
     {
         // Because old Oracle JDBC drivers don't support Connection#getSchema method.

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnection.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnection.java
@@ -78,30 +78,6 @@ public class SQLServerOutputConnection
         }
     }
 
-    public void createTable(String tableName, JdbcSchema schema) throws SQLException
-    {
-        Statement stmt = connection.createStatement();
-        try {
-            String sql = buildCreateTableSql(tableName, schema);
-            executeUpdate(stmt, sql);
-            commitIfNecessary(connection);
-        } catch (SQLException ex) {
-            throw safeRollback(connection, ex);
-        } finally {
-            stmt.close();
-        }
-    }
-
-    protected String buildCreateTableSql(String name, JdbcSchema schema)
-    {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("CREATE TABLE ");
-        quoteIdentifierString(sb, name);
-        sb.append(buildCreateTableSchemaSql(schema));
-        return sb.toString();
-    }
-
     private static final String[] SIMPLE_TYPE_NAMES = {
         "BIT", "FLOAT",
     };


### PR DESCRIPTION
An intermediate table name generated by `AbstractJdbcOutputPlugin` can already exist.
In this case `AbstractJdbcOutputPlugin` will drop the table, so the owner of the table will not work properly.
By this PR, `AbstractJdbcOutputPlugin` always create intermediate tables which don't exist yet.