### PR TITLE
Compare MySQL server and client time method.

### DIFF
--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
@@ -8,9 +8,12 @@ import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.output.jdbc.AbstractJdbcOutputPlugin;
 import org.embulk.output.jdbc.BatchInsert;
+import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.MergeConfig;
+import org.embulk.output.mysql.MySQLOutputConnection;
 import org.embulk.output.mysql.MySQLOutputConnector;
 import org.embulk.output.mysql.MySQLBatchInsert;
+import org.embulk.spi.Schema;
 
 public class MySQLOutputPlugin
         extends AbstractJdbcOutputPlugin
@@ -121,5 +124,14 @@ public class MySQLOutputPlugin
             default:
                 return false;
         }
+    }
+
+    @Override
+    protected void doBegin(JdbcOutputConnection con,
+                           PluginTask task, final Schema schema, int taskCount) throws SQLException
+    {
+        MySQLOutputConnection mySQLCon = (MySQLOutputConnection)con;
+        mySQLCon.compareTimeZone();
+        super.doBegin(con,task,schema,taskCount);
     }
 }

--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLTimeZoneComparison.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLTimeZoneComparison.java
@@ -1,0 +1,107 @@
+package org.embulk.output;
+
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class MySQLTimeZoneComparison {
+
+    private static final int ONE_HOUR_SEC = 3600;
+    private static final int ONE_MIN_SEC = 60;
+
+    private Connection connection;
+
+    private final Logger logger = Exec.getLogger(getClass());
+
+    public MySQLTimeZoneComparison(Connection connection)
+    {
+        this.connection = connection;
+    }
+
+    public void compareTimeZone()
+            throws SQLException
+    {
+        TimeZone serverTimeZone = null;
+        try {
+            serverTimeZone = getServerTimeZone();
+        }
+        catch (SQLException ex) {
+            logger.warn("Can't get server TimeZone.");
+            logger.warn(String.format(Locale.ENGLISH, "SQLException raised %s", ex.toString()));
+        }
+
+        TimeZone clientTimeZone = TimeZone.getDefault();
+        Date today = new Date();
+        int clientOffset = clientTimeZone.getRawOffset();
+
+        if (clientTimeZone.inDaylightTime(today)) {
+            clientOffset += clientTimeZone.getDSTSavings();
+        }
+
+        //
+        // Compare offset only. Although I expect to return true, the following code return false,
+        //
+        // TimeZone tz_jst   = TimeZone.getTimeZone("JST");
+        // TimeZone tz_gmt9  = TimeZone.getTimeZone("GMT+9");
+        // tz_jst.hasSameRules(tz_gmt9) // return false.
+        //
+        if (clientOffset != serverTimeZone.getRawOffset()) {
+            logger.warn(String.format(Locale.ENGLISH,
+                    "The client timezone(%s) is different from the server timezone(%s). The plugin will store wrong datetime values.",
+                    clientTimeZone.getID(), serverTimeZone.getID()));
+            logger.warn(String.format(Locale.ENGLISH,
+                    "You may need to set options `useLegacyDatetimeCode` and `serverTimezone`"));
+            logger.warn(String.format(Locale.ENGLISH,
+                    "Example. `options: { useLegacyDatetimeCode: false, serverTimezone: UTC }`"));
+        }
+        logger.warn(String.format(Locale.ENGLISH, "The plugin will set `useLegacyDatetimeCode=false` by default in future."));
+    }
+
+    private TimeZone getServerTimeZone()
+            throws SQLException
+    {
+        //
+        // First, I used `@@system_time_zone`. but It return non Time Zone Abbreviations name on a specific platform.
+        // So, This method calculate GMT offset with query.
+        //
+        String query = "select TIME_TO_SEC(timediff(now(),utc_timestamp()));";
+        Statement stmt = connection.createStatement();
+
+        try {
+            ResultSet rs = stmt.executeQuery(query);
+            if (rs.next()) {
+                int offsetSeconds = rs.getInt(1);
+                return fromGMTOffsetSeconds(offsetSeconds);
+            }
+            throw new SQLException(String.format(Locale.ENGLISH,
+                    "The timezone comparison query(%s) doesn't return the result.",query));
+        }
+        finally {
+            stmt.close();
+        }
+    }
+
+    private TimeZone fromGMTOffsetSeconds(int offsetSeconds)
+    {
+        if (offsetSeconds == 0) {
+            return TimeZone.getTimeZone("UTC");
+        }
+
+        String sign = offsetSeconds > 0 ? "+" : "-";
+        int absOffsetSec = Math.abs(offsetSeconds);
+        int tzHour = absOffsetSec / ONE_HOUR_SEC;
+        int tzMin = absOffsetSec % ONE_HOUR_SEC / ONE_MIN_SEC;
+        String tzName = String.format(Locale.ENGLISH, "GMT%s%02d:%02d", sign, tzHour, tzMin);
+        return TimeZone.getTimeZone(tzName);
+    }
+
+
+}

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.embulk.output.MySQLTimeZoneComparison;
 import org.embulk.output.jdbc.JdbcColumn;
 import org.embulk.output.jdbc.JdbcSchema;
 import org.embulk.output.jdbc.JdbcOutputConnection;
@@ -110,4 +111,11 @@ public class MySQLOutputConnection
             return super.buildColumnTypeName(c);
         }
     }
+
+    public void compareTimeZone() throws SQLException
+    {
+        MySQLTimeZoneComparison timeZoneComparison = new MySQLTimeZoneComparison(connection);
+        timeZoneComparison.compareTimeZone();
+    }
+
 }


### PR DESCRIPTION
## Summaries

@hito4t 
This is the same implementation https://github.com/embulk/embulk-input-jdbc/pull/106
This PR enable the embulk-output-mysql compare between a server and client timezone. 
After comparison, output the following logs. 

```
2017-05-24 21:18:13.840 +0900 [WARN] (0001:transaction): The client timezone(Asia/Tokyo) is different from the server timezone(UTC). The plugin will store wrong datetime values.
2017-05-24 21:18:13.841 +0900 [WARN] (0001:transaction): You may need to set options `useLegacyDatetimeCode` and `serverTimezone`
2017-05-24 21:18:13.841 +0900 [WARN] (0001:transaction): Example. `options: { useLegacyDatetimeCode: false, serverTimezone: UTC }`
2017-05-24 21:18:13.841 +0900 [WARN] (0001:transaction): The plugin will set `useLegacyDatetimeCode=false` by default in future.
```


* I need the following works. 
   * Update Connector/J (For fix case3 exception)
   * Add SSL option support.

## Test environment. 


* MySQL Server
  * Server timezone: 'UTC' launch daemon `TZ=UTC mysql.server start`
  * OS: macOS: 10.12.5
  * MySQL: 5.7.18 (Homebrew)
* Client
  * OS: macOS: 10.12.5
  * Client timezone: 'Asia/Tokyo'
  * Connector/J: 5.1.34 (current version)

## load data

```
id,account,time,purchase,comment
1,32864,2015-01-27 00:00:00,20150127,field1
2,14824,2015-01-28 01:01:01,20150127,field2
3,27559,2015-01-29 02:02:02,20150128,field3
4,11270,2015-01-30 03:03:03,20150129,field4
```

`time` is the important field. 

```
time
2015-01-27 00:00:00
2015-01-28 01:01:01
2015-01-29 02:02:02
2015-01-30 03:03:03
```

## Test summaries

* Case1: `options: { useLegacyDatetimeCode: false, serverTimezone: UTC }`
* Case2:  `options: {}`
* Case3: `options: { useLegacyDatetimeCode: false }`


| No  | connection | time         | 
|-----|------------|--------------|
|  1  | OK         | OK           |
|  2  | OK         | lag 9 hour   |
|  3  | NG         | -            |



## log

### Case1

```
mysql> select time from time_out_test;
+---------------------+
| time                |
+---------------------+
| 2015-01-27 00:00:00 |
| 2015-01-28 01:01:01 |
| 2015-01-29 02:02:02 |
| 2015-01-30 03:03:03 |
+---------------------+
4 rows in set (0.00 sec)
```

### Case2

inserted wrong time. 

```
mysql> select time from time_out_test;
+---------------------+
| time                |
+---------------------+
| 2015-01-27 09:00:00 |
| 2015-01-28 10:01:01 |
| 2015-01-29 11:02:02 |
| 2015-01-30 12:03:03 |
+---------------------+
4 rows in set (0.00 sec)
```

### Case3

Got runtime exception.

```
2017-05-24 21:13:50.146 +0900 [INFO] (0001:transaction): Loaded plugin embulk/output/mysql from a load path
2017-05-24 21:13:50.188 +0900 [INFO] (0001:transaction): Listing local files at directory 'example/csv' filtering filename by prefix 'sample_'
2017-05-24 21:13:50.189 +0900 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2017-05-24 21:13:50.192 +0900 [INFO] (0001:transaction): Loading files [example/csv/sample_01.csv]
2017-05-24 21:13:50.243 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
2017-05-24 21:13:50.265 +0900 [INFO] (0001:transaction): Connecting to jdbc:mysql://127.0.0.1:3306/embulk_test options {user=root, useLegacyDatetimeCode=false, tcpKeepAlive=true, useCompression=true, rewriteBatchedStatements=true, connectTimeout=300000, socketTimeout=1800000}
2017-05-24 21:13:50.504 +0900 [ERROR] (0001:transaction): Operation failed (0:08001)
org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException: Could not create connection to database server.
	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:373)
	at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:591)
	at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:33)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:389)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:385)
	at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
	at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:385)
	at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:180)
	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:453)
	at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:314)
	at RUBY.run(/Users/user/.embulk/bin/embulk!/embulk/runner.rb:84)
	at RUBY.run(/Users/user/.embulk/bin/embulk!/embulk/command/embulk_run.rb:269)
	at RUBY.<main>(/Users/user/.embulk/bin/embulk!/embulk/command/embulk_main.rb:2)
	at org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:850)
	at org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2976)
	at org.jruby.RubyKernel.requireCommon(org/jruby/RubyKernel.java:963)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:956)
	at org.jruby.RubyKernel$INVOKER$s$1$0$require19.call(org/jruby/RubyKernel$INVOKER$s$1$0$require19.gen)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1)
	at Users.user.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.invokeOther66:require(Users/user/$_dot_embulk/bin/embulk/embulk/command/file:/Users/user/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at Users.user.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.<main>(file:/Users/user/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:627)
	at org.jruby.Ruby.runScript(org/jruby/Ruby.java:834)
	at org.jruby.Ruby.runNormally(org/jruby/Ruby.java:749)
	at org.jruby.Ruby.runNormally(org/jruby/Ruby.java:767)
	at org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:580)
	at org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
	at org.jruby.Main.internalRun(org/jruby/Main.java:313)
	at org.jruby.Main.run(org/jruby/Main.java:242)
	at org.jruby.Main.main(org/jruby/Main.java:204)
	at org.embulk.cli.Main.main(org/embulk/cli/Main.java:23)
	Suppressed: java.lang.NullPointerException
		at org.embulk.exec.BulkLoader.doCleanup(BulkLoader.java:494)
		at org.embulk.exec.BulkLoader$3.run(BulkLoader.java:425)
		at org.embulk.exec.BulkLoader$3.run(BulkLoader.java:421)
		at org.embulk.spi.Exec.doWith(Exec.java:25)
		at org.embulk.exec.BulkLoader.cleanup(BulkLoader.java:421)
		at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:184)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:453)
		at org.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:314)
		at org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:46)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:90)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:214)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:200)
		at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:205)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:358)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:195)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:324)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
		at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:112)
		at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:99)
		at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
		at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
		at org.jruby.Ruby.runInterpreter(Ruby.java:850)
		at org.jruby.Ruby.loadFile(Ruby.java:2976)
		at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:243)
		at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:34)
		at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:885)
		at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:525)
		at org.jruby.runtime.load.LoadService.require(LoadService.java:396)
		at org.jruby.RubyKernel.requireCommon(RubyKernel.java:963)
		at org.jruby.RubyKernel.require19(RubyKernel.java:956)
		at org.jruby.RubyKernel$INVOKER$s$1$0$require19.call(RubyKernel$INVOKER$s$1$0$require19.gen)
		at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrNBlock.call(JavaMethod.java:383)
		at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:61)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:161)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
		at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
		at Users.user.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.invokeOther66:require(file:/Users/user/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
		at Users.user.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.RUBY$script(file:/Users/user/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
		at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
		at org.jruby.ir.Compiler$1.load(Compiler.java:111)
		at org.jruby.Ruby.runScript(Ruby.java:834)
		at org.jruby.Ruby.runNormally(Ruby.java:749)
		at org.jruby.Ruby.runNormally(Ruby.java:767)
		at org.jruby.Ruby.runFromMain(Ruby.java:580)
		at org.jruby.Main.doRunFromMain(Main.java:425)
		at org.jruby.Main.internalRun(Main.java:313)
		at org.jruby.Main.run(Main.java:242)
		at org.jruby.Main.main(Main.java:204)
		at org.embulk.cli.Main.main(Main.java:23)
Caused by: java.lang.RuntimeException: com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException: Could not create connection to database server.
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.begin(AbstractJdbcOutputPlugin.java:397)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.transaction(AbstractJdbcOutputPlugin.java:354)
	at org.embulk.exec.BulkLoader$4$1$1.transaction(BulkLoader.java:544)
	at org.embulk.exec.LocalExecutorPlugin.transaction(LocalExecutorPlugin.java:54)
	at org.embulk.exec.BulkLoader$4$1.run(BulkLoader.java:539)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:96)
	at org.embulk.spi.util.Filters.transaction(Filters.java:49)
	at org.embulk.exec.BulkLoader$4.run(BulkLoader.java:533)
	at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:126)
	at org.embulk.standards.CsvParserPlugin.transaction(CsvParserPlugin.java:225)
	at org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:120)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:77)
	at org.embulk.spi.util.Decoders.transaction(Decoders.java:33)
	at org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:117)
	at org.embulk.standards.LocalFileInputPlugin.resume(LocalFileInputPlugin.java:87)
	at org.embulk.standards.LocalFileInputPlugin.transaction(LocalFileInputPlugin.java:77)
	at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:67)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:528)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:389)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:385)
	at org.embulk.spi.Exec.doWith(Exec.java:25)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:385)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:453)
	at org.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:314)
	at org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:46)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:90)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:214)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:200)
	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:205)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:358)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:195)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:324)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:112)
	at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:99)
	at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
	at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
	at org.jruby.Ruby.runInterpreter(Ruby.java:850)
	at org.jruby.Ruby.loadFile(Ruby.java:2976)
	at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:243)
	at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:34)
	at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:885)
	at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:525)
	at org.jruby.runtime.load.LoadService.require(LoadService.java:396)
	at org.jruby.RubyKernel.requireCommon(RubyKernel.java:963)
	at org.jruby.RubyKernel.require19(RubyKernel.java:956)
	at org.jruby.RubyKernel$INVOKER$s$1$0$require19.call(RubyKernel$INVOKER$s$1$0$require19.gen)
	at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrNBlock.call(JavaMethod.java:383)
	at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:61)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:161)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
	at Users.user.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.invokeOther66:require(file:/Users/user/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at Users.user.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.RUBY$script(file:/Users/user/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	at org.jruby.ir.Compiler$1.load(Compiler.java:111)
	at org.jruby.Ruby.runScript(Ruby.java:834)
	at org.jruby.Ruby.runNormally(Ruby.java:749)
	at org.jruby.Ruby.runNormally(Ruby.java:767)
	at org.jruby.Ruby.runFromMain(Ruby.java:580)
	at org.jruby.Main.doRunFromMain(Main.java:425)
	at org.jruby.Main.internalRun(Main.java:313)
	at org.jruby.Main.run(Main.java:242)
	at org.jruby.Main.main(Main.java:204)
	at org.embulk.cli.Main.main(Main.java:23)
Caused by: com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException: Could not create connection to database server.
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.mysql.jdbc.Util.handleNewInstance(Util.java:377)
	at com.mysql.jdbc.Util.getInstance(Util.java:360)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:956)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:935)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:924)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:870)
	at com.mysql.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:2311)
	at com.mysql.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:2064)
	at com.mysql.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:790)
	at com.mysql.jdbc.JDBC4Connection.<init>(JDBC4Connection.java:44)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.mysql.jdbc.Util.handleNewInstance(Util.java:377)
	at com.mysql.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:395)
	at com.mysql.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:325)
	at org.embulk.output.mysql.MySQLOutputConnector.connect(MySQLOutputConnector.java:30)
	at org.embulk.output.mysql.MySQLOutputConnector.connect(MySQLOutputConnector.java:9)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.newConnection(AbstractJdbcOutputPlugin.java:246)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin$1.run(AbstractJdbcOutputPlugin.java:388)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin$RetryableSQLExecution.call(AbstractJdbcOutputPlugin.java:1088)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin$RetryableSQLExecution.call(AbstractJdbcOutputPlugin.java:1076)
	at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:100)
	at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:77)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.withRetry(AbstractJdbcOutputPlugin.java:1061)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.withRetry(AbstractJdbcOutputPlugin.java:1053)
	at org.embulk.output.jdbc.AbstractJdbcOutputPlugin.begin(AbstractJdbcOutputPlugin.java:385)
	... 88 more
Caused by: java.lang.NullPointerException
	at java.util.Properties$LineReader.readLine(Properties.java:434)
	at java.util.Properties.load0(Properties.java:353)
	at java.util.Properties.load(Properties.java:341)
	at com.mysql.jdbc.TimeUtil.loadTimeZoneMappings(TimeUtil.java:486)
	at com.mysql.jdbc.TimeUtil.getCanonicalTimezone(TimeUtil.java:404)
	at com.mysql.jdbc.ConnectionImpl.configureTimezone(ConnectionImpl.java:2009)
	at com.mysql.jdbc.ConnectionImpl.initializePropsFromServer(ConnectionImpl.java:3286)
	at com.mysql.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:2278)
	... 109 more

Error: java.lang.RuntimeException: com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException: Could not create connection to database server.
```