### PR TITLE
Update MySQL Connector/J 5.1.42

### DIFF
--- a/embulk-output-mysql/build.gradle
+++ b/embulk-output-mysql/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':embulk-output-jdbc')
-    compile 'mysql:mysql-connector-java:5.1.34'
+    compile 'mysql:mysql-connector-java:5.1.42'
 
     testCompile 'org.embulk:embulk-standards:0.8.8'
     testCompile project(':embulk-output-jdbc').sourceSets.test.output


### PR DESCRIPTION
Fix #175. 

I also need to implement `ssl` option. 

Because I got the following warning when the connector/J update to 5.1.42

> Mon Jun 05 19:30:35 JST 2017 WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.

