### PR TITLE
Support temp_schema for PostgreSQL

### DIFF
--- a/embulk-output-postgresql/README.md
+++ b/embulk-output-postgresql/README.md
@@ -16,6 +16,7 @@ PostgreSQL output plugin for Embulk loads records to PostgreSQL.
 - **password**: database login password (string, default: "")
 - **database**: destination database name (string, required)
 - **schema**: destination schema name (string, default: "public")
+- **temp_schema**: schema name for intermediate tables. by default, intermediate tables will be created in the schema specified by `schema`. replace mode doesn't support temp_schema. (string, optional)
 - **table**: destination table name (string, required)
 - **options**: extra connection properties (hash, default: {})
 - **retry_limit** max retry count for database operations (integer, default: 12)

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -267,4 +267,17 @@ public class PostgreSQLOutputConnection
         }
         return super.buildColumnTypeName(c);
     }
+
+    @Override
+    protected String buildRenameTableSql(TableIdentifier fromTable, TableIdentifier toTable)
+    {
+        // ALTER TABLE cannot change schema of table
+        StringBuilder sb = new StringBuilder();
+        sb.append("ALTER TABLE ");
+        quoteTableIdentifier(sb, fromTable);
+        sb.append(" RENAME TO ");
+        quoteIdentifierString(sb, toTable.getTableName());
+        return sb.toString();
+    }
+
 }


### PR DESCRIPTION
- Support temp_schema
- After merging #177, PostgreSQL replace mode doesn't work. This PR will fix it.
