### PR TITLE
Support temp_schema for Oracle

### DIFF
--- a/embulk-output-oracle/README.md
+++ b/embulk-output-oracle/README.md
@@ -16,6 +16,8 @@ Oracle output plugin for Embulk loads records to Oracle.
 - **user**: database login user name (string, required)
 - **password**: database login password (string, default: "")
 - **database**: destination database name (string, required if url is not set or insert_method is "oci")
+- **schema** destination schema name (string, optional)
+- **temp_schema**: schema name for intermediate tables. by default, intermediate tables will be created in the same schema as destination table. replace mode doesn't support temp_schema. (string, optional)
 - **url**: URL of the JDBC connection (string, optional)
 - **table**: destination table name (string, required)
 - **options**: extra connection properties (hash, default: {})

--- a/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
@@ -42,6 +42,10 @@ public class OracleOutputPlugin
         @ConfigDefault("null")
         public Optional<String> getSchema();
 
+        @Config("temp_schema")
+        @ConfigDefault("null")
+        public Optional<String> getTempSchema();
+
         @Config("url")
         @ConfigDefault("null")
         public Optional<String> getUrl();
@@ -120,6 +124,16 @@ public class OracleOutputPlugin
         props.setProperty("password", oracleTask.getPassword());
 
         return new OracleOutputConnector(url, props, oracleTask.getSchema().orNull(), oracleTask.getInsertMethod() == InsertMethod.direct);
+    }
+
+    @Override
+    protected TableIdentifier buildIntermediateTableId(JdbcOutputConnection con, PluginTask task, String tableName) {
+        OraclePluginTask oracleTask = (OraclePluginTask) task;
+        // replace mode doesn't support temp_schema because ALTER TABLE doesn't support schema.
+        if (oracleTask.getTempSchema().isPresent() && oracleTask.getMode() != Mode.REPLACE) {
+            return new TableIdentifier(null, oracleTask.getTempSchema().get(), tableName);
+        }
+        return super.buildIntermediateTableId(con, task, tableName);
     }
 
     @Override

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnection.java
@@ -101,6 +101,18 @@ public class OracleOutputConnection
     }
 
     @Override
+    protected String buildRenameTableSql(TableIdentifier fromTable, TableIdentifier toTable)
+    {
+        // ALTER TABLE doesn't support schema
+        StringBuilder sb = new StringBuilder();
+        sb.append("ALTER TABLE ");
+        quoteIdentifierString(sb, fromTable.getTableName());
+        sb.append(" RENAME TO ");
+        quoteIdentifierString(sb, toTable.getTableName());
+        return sb.toString();
+    }
+
+    @Override
     protected String buildPreparedInsertSql(TableIdentifier toTable, JdbcSchema toTableSchema) throws SQLException
     {
         String sql = super.buildPreparedInsertSql(toTable, toTableSchema);


### PR DESCRIPTION
- Support temp_schema
- After merging #177, Oracle replace mode doesn't work. This PR will fix it.
