### PR TITLE
Output JDBC driver version and MySQL Connector/J update warning

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -387,6 +387,7 @@ public abstract class AbstractJdbcOutputPlugin
                 public void run() throws SQLException
                 {
                     JdbcOutputConnection con = newConnection(task, true, false);
+                    con.showDriverVersion();
                     try {
                         doBegin(con, task, schema, taskCount);
                     } finally {

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -9,6 +9,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Locale;
 
 import org.slf4j.Logger;
 
@@ -19,7 +20,7 @@ import org.embulk.spi.Exec;
 public class JdbcOutputConnection
         implements AutoCloseable
 {
-    private final Logger logger = Exec.getLogger(JdbcOutputConnection.class);
+    protected final Logger logger = Exec.getLogger(JdbcOutputConnection.class);
     protected final Connection connection;
     protected final String schemaName;
     protected final DatabaseMetaData databaseMetaData;
@@ -593,4 +594,9 @@ public class JdbcOutputConnection
             return ex;
         }
     }
+    public void showDriverVersion() throws SQLException {
+        DatabaseMetaData meta = connection.getMetaData();
+        logger.info(String.format(Locale.ENGLISH,"Using JDBC Driver %s",meta.getDriverVersion()));
+    }
+
 }

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
@@ -119,4 +119,20 @@ public class MySQLOutputConnection
         timeZoneComparison.compareTimeZone();
     }
 
+    //
+    //
+    // The MySQL Connector/J 5.1.35 introduce new option `Current MySQL Connect`.
+    // It has incompatibility behavior current version and 5.1.35.
+    //
+    // This method announces users about this change before the update driver version.
+    //
+    @Override
+    public void showDriverVersion() throws SQLException {
+        super.showDriverVersion();
+        logger.warn("This plugin will update MySQL Connector/J version in the near future release.");
+        logger.warn("It has some incompatibility changes.");
+        logger.warn("For example, the 5.1.35 introduced `noTimezoneConversionForDateType` and `cacheDefaultTimezone` options.");
+        logger.warn("Please read a document and make sure configuration carefully before updating the plugin.");
+    }
+
 }


### PR DESCRIPTION
his PR the changes the following
* Output the JDBC Driver version. 
* Add MySQL Connector/J warning before an update Connector/J. 

This PR is the same https://github.com/embulk/embulk-input-jdbc/pull/110

@hito4t I wrote `con.showDriverVersion` in the `begin` method. 
It called from `transaction` and `resume`.
What do you think it is the proper place?



Output examples are below.

```
2017-06-25 10:31:32.318 +0900 [INFO] (0001:transaction): Using JDBC Driver PostgreSQL 9.4 JDBC4.1 (build 1205)
```

```
2017-06-25 10:32:53.356 +0900 [INFO] (0001:transaction): Using JDBC Driver mysql-connector-java-5.1.34 ( Revision: jess.balint@oracle.com-20141014163213-wqbwpf1ok2kvo1om )
2017-06-25 10:32:53.357 +0900 [WARN] (0001:transaction): This plugin will update MySQL Connector/J version in the near future release.
2017-06-25 10:32:53.357 +0900 [WARN] (0001:transaction): It has some incompatibility changes.
2017-06-25 10:32:53.357 +0900 [WARN] (0001:transaction): For example, the 5.1.35 introduced `noTimezoneConversionForDateType` and `cacheDefaultTimezone` options.
2017-06-25 10:32:53.357 +0900 [WARN] (0001:transaction): Please read a document and make sure configuration carefully before updating the plugin.
```