### PR TITLE
Fix Redshift output plugin merge mode

### DIFF
--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -98,7 +98,7 @@ Redshift output plugin for Embulk loads records to Redshift.
   * Transactional: Yes.
   * Resumable: No.
 * **merge**:
-  * Behavior: This mode writes rows to some intermediate tables first. If all those tasks run correctly, inserts records from intermediate tables after deleting records whose keys exist in intermediate tables. Namely, if merge keys of a record in the intermediate tables already exist in the target table, the target record is updated by the intermediate record, otherwise the intermediate record is inserted. If the target table doesn't exist, it is created automatically.
+  * Behavior: This mode writes rows to some intermediate tables first. If all those tasks run correctly, inserts new records from intermediate tables after updating records whose keys exist in intermediate tables. Namely, if merge keys of a record in the intermediate tables already exist in the target table, the target record is updated by the intermediate record, otherwise the intermediate record is inserted. If the target table doesn't exist, it is created automatically.
   * Transactional: Yes.
   * Resumable: Yes.
 

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
@@ -200,22 +200,23 @@ public class RedshiftOutputConnection
             }
             sb.append(" FROM ");
             quoteTableIdentifier(sb, fromTables.get(i));
-            sb.append(" WHERE NOT EXISTS (SELECT 1 FROM ");
-            quoteTableIdentifier(sb, toTable);
-            sb.append(", ");
-            quoteTableIdentifier(sb, fromTables.get(i));
-            sb.append(" WHERE ");
 
+            sb.append(" WHERE (");
             for (int k = 0; k < mergeKeys.size(); k++) {
-                if (k != 0) { sb.append(" AND "); }
+                if (k != 0) { sb.append(", "); }
                 quoteTableIdentifier(sb, fromTables.get(i));
                 sb.append(".");
                 quoteIdentifierString(sb, mergeKeys.get(k));
-                sb.append(" = ");
+            }
+            sb.append(") NOT IN (SELECT ");
+            for (int k = 0; k < mergeKeys.size(); k++) {
+                if (k != 0) { sb.append(", "); }
                 quoteTableIdentifier(sb, toTable);
                 sb.append(".");
                 quoteIdentifierString(sb, mergeKeys.get(k));
             }
+            sb.append(" FROM ");
+            quoteTableIdentifier(sb, toTable);
             sb.append(")) ");
         }
         sb.append(";");


### PR DESCRIPTION
There was an error in `buildCollectMergeSql` so that if any row from the temporary table existed in the target table, **no rows** from the temporary table were inserted into the target table.

I fixed that bug here, and updated the README to reflect the actual behavior (update and then insert, not delete and then insert).