### PR TITLE
Add note warning about NULL merge keys

### DIFF
--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -98,7 +98,7 @@ Redshift output plugin for Embulk loads records to Redshift.
   * Transactional: Yes.
   * Resumable: No.
 * **merge**:
-  * Behavior: This mode writes rows to some intermediate tables first. If all those tasks run correctly, inserts new records from intermediate tables after updating records whose keys exist in intermediate tables. Namely, if merge keys of a record in the intermediate tables already exist in the target table, the target record is updated by the intermediate record, otherwise the intermediate record is inserted. If the target table doesn't exist, it is created automatically.
+  * Behavior: This mode writes rows to some intermediate tables first. If all those tasks run correctly, inserts new records from intermediate tables after updating records whose keys exist in intermediate tables. Namely, if merge keys of a record in the intermediate tables already exist in the target table, the target record is updated by the intermediate record, otherwise the intermediate record is inserted. If the target table doesn't exist, it is created automatically. NOTE: Merge does not work correctly if merge keys contain `NULL`s.
   * Transactional: Yes.
   * Resumable: Yes.
 


### PR DESCRIPTION
As the description says, I just added a warning. I had a situation where one of my merge keys (I was using three) was allowed to be `NULL` and it didn't work because Redshift can't compare `NULL = NULL`.

Unfortunately, I don't think there's a way to support `NULL` merge keys.