### PR TITLE
Use DROP TABLE IF EXISTS and stop ignoring exceptions

### DIFF
--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
@@ -29,48 +29,6 @@ public class RedshiftOutputConnection
     }
 
     @Override
-    public void dropTableIfExists(TableIdentifier table) throws SQLException
-    {
-        Statement stmt = connection.createStatement();
-        try {
-            String sql = String.format("DROP TABLE IF EXISTS %s", quoteTableIdentifier(table));
-            executeUpdate(stmt, sql);
-            commitIfNecessary(connection);
-        } finally {
-            stmt.close();
-        }
-    }
-
-    @Override
-    public void replaceTable(TableIdentifier fromTable, JdbcSchema schema, TableIdentifier toTable, Optional<String> additionalSql) throws SQLException
-    {
-        Statement stmt = connection.createStatement();
-        try {
-            StringBuilder sb = new StringBuilder();
-            sb.append("BEGIN TRANSACTION;");
-            sb.append("DROP TABLE IF EXISTS ");
-            quoteTableIdentifier(sb, toTable);
-            sb.append("ALTER TABLE ");
-            quoteTableIdentifier(sb, fromTable);
-            sb.append(" RENAME TO ");
-            quoteIdentifierString(sb, toTable.getTableName());
-            sb.append("END TRANSACTION;");
-            String sql = sb.toString();
-            executeUpdate(stmt, sql);
-
-            if (additionalSql.isPresent()) {
-                executeUpdate(stmt, additionalSql.get());
-            }
-
-            commitIfNecessary(connection);
-        } catch (SQLException ex) {
-            throw safeRollback(connection, ex);
-        } finally {
-            stmt.close();
-        }
-    }
-
-    @Override
     protected String buildColumnTypeName(JdbcColumn c)
     {
         // Redshift does not support TEXT type.

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
@@ -47,17 +47,15 @@ public class RedshiftOutputConnection
         Statement stmt = connection.createStatement();
         try {
             StringBuilder sb = new StringBuilder();
+            sb.append("BEGIN TRANSACTION;");
             sb.append("DROP TABLE IF EXISTS ");
             quoteTableIdentifier(sb, toTable);
-            String sql = sb.toString();
-            executeUpdate(stmt, sql);
-
-            sb = new StringBuilder();
             sb.append("ALTER TABLE ");
             quoteTableIdentifier(sb, fromTable);
             sb.append(" RENAME TO ");
             quoteIdentifierString(sb, toTable.getTableName());
-            sql = sb.toString();
+            sb.append("END TRANSACTION;");
+            String sql = sb.toString();
             executeUpdate(stmt, sql);
 
             if (additionalSql.isPresent()) {

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
@@ -28,6 +28,23 @@ public class RedshiftOutputConnection
         connection.setAutoCommit(autoCommit);
     }
 
+    // ALTER TABLE cannot change the schema of a table
+    //
+    // Standard JDBC:
+    //     ALTER TABLE "public"."source" RENAME TO "public"."target"
+    // Redshift:
+    //     ALTER TABLE "public"."source" RENAME TO "target"
+    @Override
+    protected String buildRenameTableSql(TableIdentifier fromTable, TableIdentifier toTable)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ALTER TABLE ");
+        quoteTableIdentifier(sb, fromTable);
+        sb.append(" RENAME TO ");
+        quoteIdentifierString(sb, toTable.getTableName());
+        return sb.toString();
+    }
+
     @Override
     protected String buildColumnTypeName(JdbcColumn c)
     {


### PR DESCRIPTION
Right now we're hitting issues where we're getting errors when using replace about tables already existing. I believe that the `DROP TABLE` command is failing and we're just not seeing the error it returns. `DROP TABLE IF EXISTS` is available, this PR uses it.

I haven't tested this yet on our deployment, will be doing that asap.