### PR TITLE
Use traditional constructors of TimestampFormatter and TimestampParser against deprecation: Fix #190

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumnOption.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumnOption.java
@@ -2,7 +2,6 @@ package org.embulk.output.jdbc;
 
 import com.google.common.base.Optional;
 import org.joda.time.DateTimeZone;
-import org.jruby.embed.ScriptingContainer;
 import org.embulk.config.Task;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -27,8 +26,4 @@ public interface JdbcColumnOption
     @Config("timezone")
     @ConfigDefault("null")
     public Optional<DateTimeZone> getTimeZone();
-
-    // required by TimestampFormatter
-    @ConfigInject
-    public ScriptingContainer getJRuby();
 }


### PR DESCRIPTION
Trying to workaround the deprecation on the Embulk core side. The same as https://github.com/embulk/embulk-input-jdbc/pull/121

@hito4t @muga Can you have a look?
