### PR TITLE
Upgrade Dependency embulk-util-aws-credentials to 0.2.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
         mavenCentral()
         jcenter()
         maven {
-            url "http://dl.bintray.com/embulk-input-s3/maven"
+            url "https://dl.bintray.com/embulk-input-s3/maven"
         }
     }
 

--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -23,7 +23,7 @@ Redshift output plugin for Embulk loads records to Redshift.
 - **create_table_option** table option added to `CREATE TABLE` statement, like `CREATE TABLE <table_name> (<column1> <type1>, <column2> <type2>, ..., <create_table_constraint>) <create_table_option>`.
 - **access_key_id**: deprecated. `aws_access_key_id` should be used (see "basic" in `aws_auth_method`).
 - **secret_access_key**: deprecated. `aws_secret_access_key` should be used (see "basic" in `aws_auth_method`).
-- **aws_auth_method**: name of mechanism to authenticate requests ("basic", "env", "instance", "profile", "properties", "anonymous", or "session". default: "basic")
+- **aws_auth_method**: name of mechanism to authenticate requests ("basic", "env", "instance", "profile", "properties", "anonymous", "session" or "default". default: "basic")
 
   - "basic": uses `access_key_id` and `secret_access_key` to authenticate.
 
@@ -61,6 +61,13 @@ Redshift output plugin for Embulk loads records to Redshift.
     - **aws_secret_access_key**: AWS secret access key (string, required)
 
     - **aws_session_token**: session token (string, required)
+
+  - "default": uses AWS SDK's default strategy to look up available credentials from runtime environment. This method behaves like the combination of the following methods.
+
+    1. "env"
+    1. "properties"
+    1. "profile"
+    1. "instance"
 
 - **iam_user_name**: IAM user name for uploading temporary files to S3. The user should have permissions of `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` and `sts:GetFederationToken`. And furthermore, the user should have permission of `s3:GetBucketLocation` if Redshift region and S3 bucket region are different. (string, default: "", but we strongly recommend that you use IAM user for security reasons. see below.)
 - **s3_bucket**: S3 bucket name for temporary files

--- a/embulk-output-redshift/build.gradle
+++ b/embulk-output-redshift/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     compile "com.amazonaws:aws-java-sdk-s3:1.10.77"
     compile "com.amazonaws:aws-java-sdk-sts:1.10.77"
-	compile 'org.embulk.input.s3:embulk-util-aws-credentials:0.2.8'
+    compile 'org.embulk.input.s3:embulk-util-aws-credentials:0.2.21'
 
     testCompile project(':embulk-output-jdbc').sourceSets.test.output
 }


### PR DESCRIPTION
I  tried using this plugin on ECS Container, but it did not work.

In aws-java-sdk, this library should use `ContainerCredentialsProvider` class, but current release does not support it.

On the other hand, latest release of embulk-util-aws-credentials (0.2.9+) supports `DefaultAWSCredentialsProviderChain` with configuration value that is ’”default"'. Please support it.

regards.
