### PR TITLE
Support java.sql.Types.NUMERIC in Oracle OCI

### DIFF
--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/DirectBatchInsert.java
@@ -101,6 +101,7 @@ public class DirectBatchInsert implements BatchInsert
                     break;
 
                 case Types.DECIMAL:
+                case Types.NUMERIC:
                     // sign + size
                     int size = 1 + insertColumn.getSizeTypeParameter();
                     if (insertColumn.getSizeTypeParameter() > 0) {


### PR DESCRIPTION
`org.embulk.output.oracle.DirectBatchInsert` class supports `java.sql.Types.NUMERIC` .