### PR TITLE
update aws-java-sdk version

### DIFF
--- a/embulk-output-redshift/build.gradle
+++ b/embulk-output-redshift/build.gradle
@@ -2,8 +2,8 @@ dependencies {
     compile project(':embulk-output-jdbc')
     compile project(':embulk-output-postgresql')
 
-    compile "com.amazonaws:aws-java-sdk-s3:1.10.77"
-    compile "com.amazonaws:aws-java-sdk-sts:1.10.77"
+    compile "com.amazonaws:aws-java-sdk-s3:1.11.523"
+    compile "com.amazonaws:aws-java-sdk-sts:1.11.523"
     compile 'org.embulk.input.s3:embulk-util-aws-credentials:0.2.21'
 
     testCompile project(':embulk-output-jdbc').sourceSets.test.output


### PR DESCRIPTION
AWS Signature Version 2 is not support after June 24, 2019.

https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html
> Amazon S3 supports only AWS Signature Version 4 in most AWS Regions. In some of the older AWS Regions, Amazon S3 supports both Signature Version 4 and Signature Version 2. However, Signature Version 2 is being deprecated, and the final support for Signature Version 2 will end on June 24, 2019. For more information about the end of support for Signature Version 2, see AWS Signature Version 2 Deprecation for Amazon S3.

this pull request is update aws java sdk.
I confirmed in S3's object log that this change made AWS Signature Version 4 to be used.