### PR TITLE
Fix a bug that incorrect records will be inserted in re-retry

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -1,5 +1,6 @@
 package org.embulk.output.jdbc;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Locale;
@@ -1203,7 +1204,8 @@ public abstract class AbstractJdbcOutputPlugin
             int size = columnVisitors.size();
             int[] updateCounts = batch.getLastUpdateCounts();
             int index = 0;
-            for (Record record : pageReader.getReadRecords()) {
+            for (Iterator<? extends Record> it = pageReader.getReadRecords().iterator(); it.hasNext();) {
+                Record record = it.next();
                 // retry failed records
                 if (index >= updateCounts.length || updateCounts[index] == Statement.EXECUTE_FAILED) {
                     for (int i = 0; i < size; i++) {
@@ -1211,6 +1213,9 @@ public abstract class AbstractJdbcOutputPlugin
                         columns.get(i).visit(columnVisitor);
                     }
                     batch.add();
+                } else {
+                    // remove for re-retry
+                    it.remove();
                 }
                 index++;
             }

--- a/embulk-output-mysql/src/test/java/org/embulk/output/mysql/RetryTest.java
+++ b/embulk-output-mysql/src/test/java/org/embulk/output/mysql/RetryTest.java
@@ -169,15 +169,18 @@ public class RetryTest
                             for (int i = 1000000; i < 1260000; i++) {
                                 statement.execute("insert into test1 values('B" + i + "', 0)");
                             }
+                            System.out.println("# Inserted many records.");
 
                             synchronized (lock) {
                                 lock.notify();
                                 lock.enabled = false;
                             }
 
+                            System.out.println("# Insert 'A1249000'.");
                             statement.execute("insert into test1 values('A1249010', 0)");
                             Thread.sleep(5000);
                             // deadlock will occur
+                            System.out.println("# Insert 'A1249010'.");
                             statement.execute("insert into test1 values('A1249000', 0)");
                             conn.rollback();
                         }
@@ -293,15 +296,18 @@ public class RetryTest
                             for (int i = 1000000; i < 1260000; i++) {
                                 statement.execute("insert into test1 values('B" + i + "', 0)");
                             }
+                            System.out.println("# Inserted many records (1).");
 
                             synchronized (lock1) {
                                 lock1.notify();
                                 lock1.enabled = false;
                             }
 
+                            System.out.println("# Insert 'A1249010'.");
                             statement.execute("insert into test1 values('A1249010', 0)");
                             Thread.sleep(5000);
                             // deadlock will occur
+                            System.out.println("# Insert 'A1249000'.");
                             statement.execute("insert into test1 values('A1249000', 0)");
                             conn.rollback();
                         }
@@ -324,16 +330,19 @@ public class RetryTest
                             for (int i = 1000000; i < 1260000; i++) {
                                 statement.execute("insert into test1 values('C" + i + "', 0)");
                             }
+                            System.out.println("# Inserted many records (2).");
 
                             synchronized (lock2) {
                                 lock2.notify();
                                 lock2.enabled = false;
                             }
 
-                            statement.execute("insert into test1 values('A1249020', 0)");
-                            Thread.sleep(10000);
+                            System.out.println("# Insert 'A1249030'.");
+                            statement.execute("insert into test1 values('A1249030', 0)");
+                            Thread.sleep(20000);
                             // deadlock will occur
-                            statement.execute("insert into test1 values('A1249005', 0)");
+                            System.out.println("# Insert 'A1249020'.");
+                            statement.execute("insert into test1 values('A1249020', 0)");
                             conn.rollback();
                         }
                     }


### PR DESCRIPTION
embulk-output-jdbc holds a list of records to insert for retry.
But incorrect records will be inserted in re-retry because the list won't updated in retry.
This PR fix that by updating the list in retry.