### PR TITLE
Introduce connection_timeout and socket_timeout to sqlserver

### DIFF
--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -10,7 +10,7 @@ SQL Server output plugin for Embulk loads records to SQL Server.
 
 ## Configuration
 
-- **driver_path**: path to the jar file of Microsoft SQL Server JDBC driver. If not set, Microsoft SQL Server JDBC driver v7.2.2 will be used as default
+- **driver_path**: path to the jar file of Microsoft SQL Server JDBC driver. If not set, open-source driver (jTDS driver) is used (string)
 - **host**: database host name (string, required)
 - **port**: database port number (integer, default: 1433)
 - **integratedSecutiry**: whether to use integrated authentication or not. The `sqljdbc_auth.dll` must be located on Java library path if using integrated authentication. : (boolean, default: false)

--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -48,7 +48,8 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **timezone**: If input column type (embulk type) is timestamp, this plugin needs to format the timestamp value into a SQL string. In this cases, this timezone option is used to control the timezone. (string, value of default_timezone option is used by default)
 - **before_load**: if set, this SQL will be executed before loading all records. In truncate_insert mode, the SQL will be executed after truncating. replace mode doesn't support this option.
 - **after_load**: if set, this SQL will be executed after loading all records.
-
+- **connect_timeout**: timeout for the driver to connect. 0 means the default of SQL Server (15 by default). (integer (seconds), default: 300)
+- **socket_timeout**: timeout for executing the query. 0 means no timeout. (integer (seconds), default: 1800)
 ### Modes
 
 * **insert**:

--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -10,7 +10,7 @@ SQL Server output plugin for Embulk loads records to SQL Server.
 
 ## Configuration
 
-- **driver_path**: path to the jar file of Microsoft SQL Server JDBC driver. If not set, open-source driver (jTDS driver) is used (string)
+- **driver_path**: path to the jar file of Microsoft SQL Server JDBC driver. If not set, Microsoft SQL Server JDBC driver v7.2.2 will be used as default
 - **host**: database host name (string, required)
 - **port**: database port number (integer, default: 1433)
 - **integratedSecutiry**: whether to use integrated authentication or not. The `sqljdbc_auth.dll` must be located on Java library path if using integrated authentication. : (boolean, default: false)

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
@@ -94,10 +94,12 @@ public class SQLServerOutputPlugin
         public String getDatabaseEncoding();
 
         @Config("connect_timeout")
-        public int getConnectTimeout();
+        @ConfigDefault("null")
+        public Optional<Integer> getConnectTimeout();
 
         @Config("socket_timeout")
-        public int getSocketTimeout();
+        @ConfigDefault("null")
+        public Optional<Integer> getSocketTimeout();
     }
 
     private static class UrlAndProperties {
@@ -239,7 +241,7 @@ public class SQLServerOutputPlugin
                 throw new ConfigException("'user' option is required but not set.");
             }
 
-            props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout())); // seconds
+            props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout().or(0))); // seconds
         }else {
             StringBuilder urlBuilder = new StringBuilder();
             if (sqlServerTask.getInstance().isPresent()) {
@@ -262,11 +264,11 @@ public class SQLServerOutputPlugin
                     throw new IllegalArgumentException("Field 'password' is not set.");
                 }
             }
-            props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout() * 1000)); // milliseconds
+            props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout().or(0) * 1000)); // milliseconds
             url = urlBuilder.toString();
         }
 
-        props.setProperty("loginTimeout", String.valueOf(sqlServerTask.getConnectTimeout())); // seconds
+        props.setProperty("loginTimeout", String.valueOf(sqlServerTask.getConnectTimeout().or(0))); // seconds
 
         return new UrlAndProperties(url, props);
     }

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
@@ -92,6 +92,14 @@ public class SQLServerOutputPlugin
         @Config("database_encoding")
         @ConfigDefault("\"MS932\"")
         public String getDatabaseEncoding();
+
+        @Config("connect_timeout")
+        @ConfigDefault("300")
+        public int getConnectTimeout();
+
+        @Config("socket_timeout")
+        @ConfigDefault("1800")
+        public int getSocketTimeout();
     }
 
     private static class UrlAndProperties {
@@ -232,6 +240,8 @@ public class SQLServerOutputPlugin
             if (!sqlServerTask.getUser().isPresent()) {
                 throw new ConfigException("'user' option is required but not set.");
             }
+
+            props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout())); // seconds
         }else {
             StringBuilder urlBuilder = new StringBuilder();
             if (sqlServerTask.getInstance().isPresent()) {
@@ -254,8 +264,11 @@ public class SQLServerOutputPlugin
                     throw new IllegalArgumentException("Field 'password' is not set.");
                 }
             }
+            props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout() * 1000)); // milliseconds
             url = urlBuilder.toString();
         }
+
+        props.setProperty("loginTimeout", String.valueOf(sqlServerTask.getConnectTimeout())); // seconds
 
         return new UrlAndProperties(url, props);
     }

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
@@ -94,11 +94,9 @@ public class SQLServerOutputPlugin
         public String getDatabaseEncoding();
 
         @Config("connect_timeout")
-        @ConfigDefault("300")
         public int getConnectTimeout();
 
         @Config("socket_timeout")
-        @ConfigDefault("1800")
         public int getSocketTimeout();
     }
 


### PR DESCRIPTION
Currently I meet some trouble after submits the insert query to the server, the job waits for the response but somehow can’t get it and wait forever.

It can be considered as a bug of jTDS lib  as mentioned here: 
https://sourceforge.net/p/jtds/discussion/104389/thread/c3979289/
https://sourceforge.net/p/jtds/bugs/520/ (closed but not resolved)

I think we should introduce timeout for this case. 

How to test this: 
Let's say we start a new transaction and lock the same table when the job is running. It will wait there

`BEGIN TRANSACTION

SELECT * FROM ableTest_0000016c24cdd32d_embulk000 WITH (TABLOCKX, HOLDLOCK)

WHERE 0 = 1

WAITFOR DELAY '02:00'

ROLLBACK TRANSACTION` 