### PR TITLE
Replace jtds by mssql:jdbc

### DIFF
--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -10,7 +10,7 @@ SQL Server output plugin for Embulk loads records to SQL Server.
 
 ## Configuration
 
-- **driver_path**: path to the jar file of Microsoft SQL Server JDBC driver. If not set, open-source driver (jTDS driver) is used (string)
+- **driver_path**: path to the jar file of Microsoft SQL Server JDBC driver. If not set, Microsoft SQL Server JDBC driver v7.2.2 will be used as default
 - **host**: database host name (string, required)
 - **port**: database port number (integer, default: 1433)
 - **integratedSecutiry**: whether to use integrated authentication or not. The `sqljdbc_auth.dll` must be located on Java library path if using integrated authentication. : (boolean, default: false)

--- a/embulk-output-sqlserver/build.gradle
+++ b/embulk-output-sqlserver/build.gradle
@@ -1,8 +1,6 @@
 dependencies {
     compile project(':embulk-output-jdbc')
-    compile 'net.sourceforge.jtds:jtds:1.3.1'
-
+    compile 'com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8'
     testCompile 'org.embulk:embulk-standards:0.8.22'
     testCompile project(':embulk-output-jdbc').sourceSets.test.output
-    testCompile files('test_jdbc_driver/sqljdbc41.jar')
 }

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnection.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnection.java
@@ -47,6 +47,15 @@ public class SQLServerOutputConnection
             return "TEXT";
         case "TIMESTAMP":
             return "DATETIME2";
+        case "NVARCHAR":
+            if(c.getSizeTypeParameter() > 8000) {
+                return "NVARCHAR(max)";
+            }
+        case "VARCHAR":
+            if(c.getSizeTypeParameter() > 8000) {
+                return "VARCHAR(max)";
+            }
+
         default:
             return super.buildColumnTypeName(c);
         }

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/setter/SQLServerColumnSetterFactory.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/setter/SQLServerColumnSetterFactory.java
@@ -7,6 +7,7 @@ import org.embulk.output.jdbc.JdbcColumn;
 import org.embulk.output.jdbc.JdbcColumnOption;
 import org.embulk.output.jdbc.setter.ColumnSetter;
 import org.embulk.output.jdbc.setter.ColumnSetterFactory;
+import org.embulk.output.jdbc.setter.StringColumnSetter;
 import org.joda.time.DateTimeZone;
 
 public class SQLServerColumnSetterFactory
@@ -42,6 +43,12 @@ public class SQLServerColumnSetterFactory
         case "time":
             return new SQLServerSqlTimeColumnSetter(batch, column, newDefaultValueSetter(column, option), newCalendar(option));
 
+        case "coerce":
+            {
+                if(column.getName().equals("datetimeoffset") || column.getName().equals("sql_variant")) {
+                    return new StringColumnSetter(batch, column, newDefaultValueSetter(column, option), newTimestampFormatter(option));
+                }
+            }
         default:
             return super.newColumnSetter(column, option);
         }

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/setter/SQLServerColumnSetterFactory.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/setter/SQLServerColumnSetterFactory.java
@@ -45,7 +45,11 @@ public class SQLServerColumnSetterFactory
 
         case "coerce":
             {
-                if(column.getName().equals("datetimeoffset") || column.getName().equals("sql_variant")) {
+                if(column.getName().equals("datetimeoffset")
+                        || column.getName().equals("sql_variant")
+                        || column.getName().equals("date")
+                        || column.getName().equals("time")
+                        || column.getName().equals("datetime2")) {
                     return new StringColumnSetter(batch, column, newDefaultValueSetter(column, option), newTimestampFormatter(option));
                 }
             }

--- a/embulk-output-sqlserver/src/test/java/org/embulk/output/sqlserver/BasicTest.java
+++ b/embulk-output-sqlserver/src/test/java/org/embulk/output/sqlserver/BasicTest.java
@@ -11,7 +11,6 @@ import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 
-import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.output.SQLServerOutputPlugin;
 import org.embulk.spi.OutputPlugin;
@@ -175,20 +174,6 @@ public class BasicTest
         TestingEmbulk.RunResult result1 = embulk.runOutput(baseConfig.merge(loadYamlResource(embulk, "test_string_timestamp.yml")), in1);
         assertThat(selectRecords(embulk, "TEST1"), is(readResource("test_string_timestamp_expected.csv")));
         //assertThat(result1.getConfigDiff(), is((ConfigDiff) loadYamlResource(embulk, "test_expected.diff")));
-    }
-
-    @Test
-    public void testJtds() throws Exception
-    {
-        SQLServerOutputPlugin.preferMicrosoftDriver = false;
-        try {
-            Path in1 = toPath("test1.csv");
-            TestingEmbulk.RunResult result1 = embulk.runOutput(baseConfig.merge(loadYamlResource(embulk, "test_insert.yml")), in1);
-            assertThat(selectRecords(embulk, "TEST1"), is(readResource("test_insert_expected.csv")));
-            //assertThat(result1.getConfigDiff(), is((ConfigDiff) loadYamlResource(embulk, "test_expected.diff")));
-        } finally {
-            SQLServerOutputPlugin.preferMicrosoftDriver = true;
-        }
     }
 
     private Path toPath(String fileName) throws URISyntaxException

--- a/embulk-output-sqlserver/src/test/java/org/embulk/output/sqlserver/SQLServerTests.java
+++ b/embulk-output-sqlserver/src/test/java/org/embulk/output/sqlserver/SQLServerTests.java
@@ -37,7 +37,7 @@ public class SQLServerTests
         Integer port = config.get(Integer.class, "port");
         String database = config.get(String.class, "database");
 
-        String url = String.format("jdbc:jtds:sqlserver://%s:%d/%s", host, port, database);
+        String url = String.format("jdbc:sqlserver://%s:%d;databaseName=%s", host, port, database);
 
         return DriverManager.getConnection(url, user, password);
     }


### PR DESCRIPTION
`JTDS` driver is quite old and not maintained for a long time and `mssql` driver is now open source.
We should keep the output syn with input also by replacing `JTDS` by `mssql` driver. 
