### PR TITLE
Support non-default schema in MSSQL "native" mode

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/TableIdentifier.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/TableIdentifier.java
@@ -9,10 +9,10 @@ public class TableIdentifier
     private String schemaName;
     private String tableName;
 
-    public TableIdentifier(String database, String shcemaName, String tableName)
+    public TableIdentifier(String database, String schemaName, String tableName)
     {
         this.database = database;
-        this.schemaName = shcemaName;
+        this.schemaName = schemaName;
         this.tableName = tableName;
     }
 

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/NativeBatchInsert.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/NativeBatchInsert.java
@@ -66,7 +66,8 @@ public class NativeBatchInsert implements BatchInsert
     public void prepare(TableIdentifier loadTable, JdbcSchema insertSchema) throws SQLException
     {
         columnCount = insertSchema.getCount();
-        client.open(server, port, instance, database, user, password, loadTable.getTableName(), nativeDriverName, databaseEncoding);
+        client.open(server, port, instance, database, user, password,
+                loadTable.getSchemaName(), loadTable.getTableName(), nativeDriverName, databaseEncoding);
         formats = new DateFormat[insertSchema.getCount()];
         for (int i = 0; i < insertSchema.getCount(); i++) {
             JdbcColumn column = insertSchema.getColumn(i);

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/nativeclient/NativeClientWrapper.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/nativeclient/NativeClientWrapper.java
@@ -70,7 +70,7 @@ public class NativeClientWrapper
 
     public void open(String server, int port, Optional<String> instance,
             String database, Optional<String> user, Optional<String> password,
-            String table, Optional<String> nativeDriverName,
+            String schemaName, String table, Optional<String> nativeDriverName,
             String databaseEncoding)
                     throws SQLException
     {
@@ -141,8 +141,9 @@ public class NativeClientWrapper
         StringBuilder fullTableName = new StringBuilder();
         fullTableName.append("[");
         fullTableName.append(database);
-        fullTableName.append("].");
-        fullTableName.append(".[");
+        fullTableName.append("].[");
+        fullTableName.append(schemaName);
+        fullTableName.append("].[");
         fullTableName.append(table);
         fullTableName.append("]");
         checkBCPResult("bcp_init", client.bcp_initW(
@@ -381,7 +382,7 @@ public class NativeClientWrapper
             throwException(operation, NativeClient.FAIL);
         } else {
             if (result > 0) {
-                logger.info(String.format("SQL Server Native Client : %,d rows have bean loaded.", result));
+                logger.info(String.format("SQL Server Native Client : %,d rows have been loaded.", result));
             }
         }
 


### PR DESCRIPTION
The `schema` and `temp_schema` configuration properties are ignored when using `insert_method: native`. Presumably they default to the user's default schema, as [bcp_init](https://docs.microsoft.com/lb-lu/sql/relational-databases/native-client-odbc-extensions-bulk-copy-functions/bcp-init?view=sql-server-ver15) is called with the `table` parameter set to `[db_name]..[table_name]`.

The fix is trivial, but note that I've only been able to test this manually and only in `mode: insert_direct`. It _seems_ that `loadTable.getSchemaName()` is not supposed to be null, but it's hard to be sure. Please check if this is correct.
