### PR TITLE
Add: create_table_constraint option usage in README

### DIFF
--- a/embulk-output-mysql/README.md
+++ b/embulk-output-mysql/README.md
@@ -119,6 +119,17 @@ out:
     my_col_5: {type: 'DECIMAL(18,9)', value_type: pass}
 ```
 
+You can add a primary key, index, unique key..etc with `create_table_constraint`, `column options`
+
+```yaml
+out:
+  type: mysql
+  # snip
+  create_table_constraint: 'primary key(id)'
+  column_options:
+    id: {type: 'int auto_increment'}
+```
+
 ### Build
 
 ```


### PR DESCRIPTION
I would added create_table_constraint, column options example in README "Advanced configuration" part.

ref: https://qiita.com/play-life/items/2805ecb12ede6fa04c44#comment-d5e32180fac106adf60c