### PR TITLE
Replace Guava Optional to java.util.Optional

### DIFF
--- a/embulk-output-db2/src/main/java/org/embulk/output/DB2OutputPlugin.java
+++ b/embulk-output-db2/src/main/java/org/embulk/output/DB2OutputPlugin.java
@@ -3,6 +3,7 @@ package org.embulk.output;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Optional;
 
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -13,7 +14,6 @@ import org.embulk.output.jdbc.JdbcOutputConnector;
 import org.embulk.output.jdbc.BatchInsert;
 import org.embulk.output.jdbc.MergeConfig;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import static java.util.Locale.ENGLISH;
 

--- a/embulk-output-db2/src/main/java/org/embulk/output/db2/DB2BatchInsert.java
+++ b/embulk-output-db2/src/main/java/org/embulk/output/db2/DB2BatchInsert.java
@@ -2,12 +2,11 @@ package org.embulk.output.db2;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import org.embulk.output.jdbc.JdbcOutputConnector;
 import org.embulk.output.jdbc.MergeConfig;
 import org.embulk.output.jdbc.StandardBatchInsert;
-
-import com.google.common.base.Optional;
 
 public class DB2BatchInsert
         extends StandardBatchInsert

--- a/embulk-output-db2/src/main/java/org/embulk/output/db2/DB2OutputConnector.java
+++ b/embulk-output-db2/src/main/java/org/embulk/output/db2/DB2OutputConnector.java
@@ -3,13 +3,12 @@ package org.embulk.output.db2;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.Properties;
 
 import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.AbstractJdbcOutputConnector;
 import org.embulk.output.jdbc.TransactionIsolation;
-
-import com.google.common.base.Optional;
 
 public class DB2OutputConnector
         extends AbstractJdbcOutputConnector

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/JdbcOutputPlugin.java
@@ -5,8 +5,8 @@ import java.sql.Driver;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 
@@ -83,7 +83,7 @@ public class JdbcOutputPlugin
         logConnectionProperties(t.getUrl(), props);
 
         return new GenericOutputConnector(t.getUrl(), props, t.getDriverClass(),
-                t.getSchema().orNull());
+                t.getSchema().orElse(null));
     }
 
     private static class GenericOutputConnector

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputConnector.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputConnector.java
@@ -1,8 +1,7 @@
 package org.embulk.output.jdbc;
 
 import java.sql.SQLException;
-
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 public abstract class AbstractJdbcOutputConnector implements JdbcOutputConnector
 {

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumn.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumn.java
@@ -1,9 +1,9 @@
 package org.embulk.output.jdbc;
 
-import com.google.common.base.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Optional;
 
 public class JdbcColumn
 {
@@ -46,7 +46,7 @@ public class JdbcColumn
     {
         return new JdbcColumn(name, sqlType,
                 simpleTypeName, sizeTypeParameter, scaleTypeParameter, dataLength,
-                Optional.<String>absent(), isNotNull, isUniqueKey);
+                Optional.<String>empty(), isNotNull, isUniqueKey);
     }
 
     public static JdbcColumn newGenericTypeColumn(String name, int sqlType,
@@ -55,7 +55,7 @@ public class JdbcColumn
     {
         return new JdbcColumn(name, sqlType,
                 simpleTypeName, sizeTypeParameter, scaleTypeParameter, sizeTypeParameter,
-                Optional.<String>absent(), isNotNull, isUniqueKey);
+                Optional.<String>empty(), isNotNull, isUniqueKey);
     }
 
     public static JdbcColumn newTypeDeclaredColumn(String name, int sqlType,
@@ -69,7 +69,7 @@ public class JdbcColumn
     @JsonIgnore
     public static JdbcColumn skipColumn()
     {
-        return new JdbcColumn(null, 0, null, 0, 0, 0, Optional.<String>absent(), false, false);
+        return new JdbcColumn(null, 0, null, 0, 0, 0, Optional.<String>empty(), false, false);
     }
 
     @JsonIgnore

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumnOption.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumnOption.java
@@ -1,6 +1,6 @@
 package org.embulk.output.jdbc;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.joda.time.DateTimeZone;
 import org.embulk.config.Task;
 import org.embulk.config.Config;

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -10,11 +10,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
 
 public class JdbcOutputConnection
         implements AutoCloseable

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcSchema.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcSchema.java
@@ -1,10 +1,10 @@
 package org.embulk.output.jdbc;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.embulk.config.ConfigException;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -48,7 +48,7 @@ public class JdbcSchema
         if (foundColumn != null) {
             return Optional.of(foundColumn);
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     public int getCount()

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/MergeConfig.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/MergeConfig.java
@@ -1,8 +1,7 @@
 package org.embulk.output.jdbc;
 
-import com.google.common.base.Optional;
-
 import java.util.List;
+import java.util.Optional;
 
 public class MergeConfig {
     private final List<String> mergeKeys;

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
@@ -8,7 +8,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Time;
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.embulk.spi.time.Timestamp;

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/ToString.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/ToString.java
@@ -1,11 +1,11 @@
 package org.embulk.output.jdbc;
 
-import com.google.common.base.Optional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Optional;
 
 public class ToString
 {
@@ -19,7 +19,7 @@ public class ToString
     @JsonCreator
     ToString(Optional<JsonNode> option) throws JsonMappingException
     {
-        JsonNode node = option.or(NullNode.getInstance());
+        JsonNode node = option.orElse(NullNode.getInstance());
         if (node.isTextual()) {
             this.string = node.textValue();
         } else if (node.isValueNode()) {

--- a/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/MySQLOutputPlugin.java
@@ -3,8 +3,7 @@ package org.embulk.output;
 import java.util.Properties;
 import java.io.IOException;
 import java.sql.SQLException;
-
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLBatchInsert.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLBatchInsert.java
@@ -3,7 +3,7 @@ package org.embulk.output.mysql;
 import java.io.IOException;
 import java.sql.Types;
 import java.sql.SQLException;
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.embulk.output.jdbc.JdbcOutputConnector;
 import org.embulk.output.jdbc.MergeConfig;
 import org.embulk.output.jdbc.StandardBatchInsert;

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnector.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnector.java
@@ -4,12 +4,11 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.AbstractJdbcOutputConnector;
 import org.embulk.output.jdbc.TransactionIsolation;
-
-import com.google.common.base.Optional;
 
 public class MySQLOutputConnector
         extends AbstractJdbcOutputConnector

--- a/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/OracleOutputPlugin.java
@@ -3,8 +3,8 @@ package org.embulk.output;
 import java.util.Properties;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
 import org.embulk.config.Config;
@@ -123,7 +123,7 @@ public class OracleOutputPlugin
         props.setProperty("password", oracleTask.getPassword());
         logConnectionProperties(url, props);
 
-        return new OracleOutputConnector(url, props, oracleTask.getSchema().orNull(), oracleTask.getInsertMethod() == InsertMethod.direct,
+        return new OracleOutputConnector(url, props, oracleTask.getSchema().orElse(null), oracleTask.getInsertMethod() == InsertMethod.direct,
                 oracleTask.getTransactionIsolation());
     }
 

--- a/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnector.java
+++ b/embulk-output-oracle/src/main/java/org/embulk/output/oracle/OracleOutputConnector.java
@@ -4,12 +4,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Optional;
 
 import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.AbstractJdbcOutputConnector;
 import org.embulk.output.jdbc.TransactionIsolation;
-
-import com.google.common.base.Optional;
 
 public class OracleOutputConnector
         extends AbstractJdbcOutputConnector

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Properties;
+import java.util.Optional;
 
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -17,7 +18,6 @@ import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.Schema;
 import org.joda.time.DateTimeZone;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnector.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnector.java
@@ -4,12 +4,11 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.AbstractJdbcOutputConnector;
 import org.embulk.output.jdbc.TransactionIsolation;
-
-import com.google.common.base.Optional;
 
 public class PostgreSQLOutputConnector
         extends AbstractJdbcOutputConnector

--- a/embulk-output-redshift/build.gradle
+++ b/embulk-output-redshift/build.gradle
@@ -15,7 +15,7 @@ dependencies {
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     }
-    compile("org.embulk.input.s3:embulk-util-aws-credentials:0.2.21") {
+    compile("org.embulk.input.s3:embulk-util-aws-credentials:0.3.5") {
         exclude group: "org.embulk", module: "embulk-core"
         exclude group: "org.slf4j", module: "slf4j-api"
     }

--- a/embulk-output-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -11,7 +11,7 @@ commons-codec:commons-codec:1.10
 commons-logging:commons-logging:1.2
 org.apache.httpcomponents:httpclient:4.5.5
 org.apache.httpcomponents:httpcore:4.4.9
-org.embulk.input.s3:embulk-util-aws-credentials:0.2.21
+org.embulk.input.s3:embulk-util-aws-credentials:0.3.5
 org.postgresql:postgresql:9.4-1205-jdbc41
 org.slf4j:jcl-over-slf4j:1.7.12
 software.amazon.ion:ion-java:1.0.2

--- a/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
@@ -3,10 +3,10 @@ package org.embulk.output;
 import java.util.Properties;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import org.embulk.util.aws.credentials.AwsCredentials;
@@ -201,6 +201,6 @@ public class RedshiftOutputPlugin
         RedshiftPluginTask t = (RedshiftPluginTask) task;
         setAWSCredentialsBackwardCompatibility(t);
         return new RedshiftCopyBatchInsert(getConnector(task, true),
-                getAWSCredentialsProvider(t), t.getS3Bucket(), t.getS3KeyPrefix(), t.getIamUserName(), t.getDeleteS3TempFile(), t.getCopyIamRoleName().orNull(), t.getCopyAwsAccountId().orNull());
+                getAWSCredentialsProvider(t), t.getS3Bucket(), t.getS3KeyPrefix(), t.getIamUserName(), t.getDeleteS3TempFile(), t.getCopyIamRoleName().orElse(null), t.getCopyAwsAccountId().orElse(null));
     }
 }

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnector.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnector.java
@@ -4,12 +4,11 @@ import java.util.Properties;
 import java.sql.Driver;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import org.embulk.output.jdbc.AbstractJdbcOutputConnector;
 import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.TransactionIsolation;
-
-import com.google.common.base.Optional;
 
 public class RedshiftOutputConnector
         extends AbstractJdbcOutputConnector

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
@@ -1,6 +1,5 @@
 package org.embulk.output;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
 import org.embulk.config.Config;
@@ -23,6 +22,7 @@ import org.joda.time.DateTimeZone;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Optional;
 
 import static java.util.Locale.ENGLISH;
 
@@ -171,7 +171,7 @@ public class SQLServerOutputPlugin
 
         UrlAndProperties urlProps = getUrlAndProperties(sqlServerTask, useJtdsDriver);
         logConnectionProperties(urlProps.getUrl(), urlProps.getProps());
-        return new SQLServerOutputConnector(urlProps.getUrl(), urlProps.getProps(), sqlServerTask.getSchema().orNull(),
+        return new SQLServerOutputConnector(urlProps.getUrl(), urlProps.getProps(), sqlServerTask.getSchema().orElse(null),
                 sqlServerTask.getTransactionIsolation());
     }
 

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/NativeBatchInsert.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/NativeBatchInsert.java
@@ -7,6 +7,7 @@ import java.sql.Types;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Optional;
 
 import org.embulk.output.jdbc.BatchInsert;
 import org.embulk.output.jdbc.JdbcColumn;
@@ -18,8 +19,6 @@ import org.embulk.output.sqlserver.nativeclient.NativeClientWrapper;
 import org.embulk.spi.time.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
 
 public class NativeBatchInsert implements BatchInsert
 {

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnector.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnector.java
@@ -6,15 +6,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Optional;
 
 import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.AbstractJdbcOutputConnector;
 import org.embulk.output.jdbc.TransactionIsolation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
-
 
 public class SQLServerOutputConnector
         extends AbstractJdbcOutputConnector

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/nativeclient/NativeClientWrapper.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/nativeclient/NativeClientWrapper.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Platform;
@@ -16,8 +17,6 @@ import jnr.ffi.provider.jffi.ArrayMemoryIO;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
 
 public class NativeClientWrapper
 {


### PR DESCRIPTION
Along with it, it upgrades `embulk-util-aws-credentials` for `embulk-output-redshift` so that it uses `java.util.Optional`.