### PR TITLE
Adding support for SET ROLE to PostgreSQL

### DIFF
--- a/embulk-output-postgresql/README.md
+++ b/embulk-output-postgresql/README.md
@@ -37,6 +37,7 @@ PostgreSQL output plugin for Embulk loads records to PostgreSQL.
   - **value_type**: This plugin converts input column type (embulk type) into a database type to build a INSERT statement. This value_type option controls the type of the value in a INSERT statement. (string, default: depends on the sql type of the column. Available values options are: `byte`, `short`, `int`, `long`, `double`, `float`, `boolean`, `string`, `nstring`, `date`, `time`, `timestamp`, `decimal`, `json`, `null`, `pass`)
   - **timestamp_format**: If input column type (embulk type) is timestamp and value_type is `string` or `nstring`, this plugin needs to format the timestamp value into a string. This timestamp_format option is used to control the format of the timestamp. (string, default: `%Y-%m-%d %H:%M:%S.%6N`)
   - **timezone**: If input column type (embulk type) is timestamp, this plugin needs to format the timestamp value into a SQL string. In this cases, this timezone option is used to control the timezone. (string, value of default_timezone option is used by default)
+- **set_role**: name of a role to execute statements. If this option is set, it executes `SET ROLE "..."` statement every time when a new connection is established (string)
 - **before_load**: if set, this SQL will be executed before loading all records. In truncate_insert mode, the SQL will be executed after truncating. replace mode doesn't support this option.
 - **after_load**: if set, this SQL will be executed after loading all records.
 

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
@@ -58,6 +58,10 @@ public class PostgreSQLOutputPlugin
         @Config("ssl")
         @ConfigDefault("false")
         public boolean getSsl();
+
+        @Config("set_role")
+        @ConfigDefault("null")
+        public Optional<String> getSetRole();
     }
 
     @Override
@@ -113,7 +117,8 @@ public class PostgreSQLOutputPlugin
         props.setProperty("password", t.getPassword());
         logConnectionProperties(url, props);
 
-        return new PostgreSQLOutputConnector(url, props, t.getSchema(), t.getTransactionIsolation());
+        return new PostgreSQLOutputConnector(url, props, t.getSchema(), t.getTransactionIsolation(),
+                t.getSetRole().orElse(null));
     }
 
     @Override

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnector.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnector.java
@@ -16,14 +16,16 @@ public class PostgreSQLOutputConnector
     private final String url;
     private final Properties properties;
     private final String schemaName;
+    private final String roleName;
 
     public PostgreSQLOutputConnector(String url, Properties properties, String schemaName,
-            Optional<TransactionIsolation> transactionIsolation)
+            Optional<TransactionIsolation> transactionIsolation, String roleName)
     {
         super(transactionIsolation);
         this.url = url;
         this.properties = properties;
         this.schemaName = schemaName;
+        this.roleName = roleName;
     }
 
     @Override
@@ -31,7 +33,7 @@ public class PostgreSQLOutputConnector
     {
         Connection c = DriverManager.getConnection(url, properties);
         try {
-            PostgreSQLOutputConnection con = new PostgreSQLOutputConnection(c, schemaName);
+            PostgreSQLOutputConnection con = new PostgreSQLOutputConnection(c, schemaName, roleName);
             c = null;
             return con;
         } finally {

--- a/embulk-output-postgresql/src/test/java/org/embulk/output/postgresql/BasicTest.java
+++ b/embulk-output-postgresql/src/test/java/org/embulk/output/postgresql/BasicTest.java
@@ -133,4 +133,14 @@ public class BasicTest
         return FileSystems.getDefault().getPath(new File(url.toURI()).getAbsolutePath());
     }
 
+    @Test
+    public void testSetRole() throws Exception
+    {
+        Path in1 = toPath("test_string.csv");
+        baseConfig.set("set_role", baseConfig.get(String.class, "user"));
+        TestingEmbulk.RunResult result1 = embulk.runOutput(baseConfig, in1);
+        assertThat(selectRecords(embulk, "test_string"), is(readResource("test_replace_expected.csv")));
+        //assertThat(result1.getConfigDiff(), is((ConfigDiff) loadYamlResource(embulk, "test_expected.diff")));
+    }
+
 }

--- a/embulk-output-postgresql/src/test/java/org/embulk/output/postgresql/BasicTest.java
+++ b/embulk-output-postgresql/src/test/java/org/embulk/output/postgresql/BasicTest.java
@@ -137,9 +137,10 @@ public class BasicTest
     public void testSetRole() throws Exception
     {
         Path in1 = toPath("test_string.csv");
-        baseConfig.set("set_role", baseConfig.get(String.class, "user"));
-        TestingEmbulk.RunResult result1 = embulk.runOutput(baseConfig, in1);
-        assertThat(selectRecords(embulk, "test_string"), is(readResource("test_replace_expected.csv")));
+        ConfigSource config = baseConfig.merge(loadYamlResource(embulk, "test_string.yml"));
+        config.set("set_role", baseConfig.get(String.class, "user"));
+        TestingEmbulk.RunResult result1 = embulk.runOutput(config, in1);
+        assertThat(selectRecords(embulk, "test_string"), is(readResource("test_string_expected.csv")));
         //assertThat(result1.getConfigDiff(), is((ConfigDiff) loadYamlResource(embulk, "test_expected.diff")));
     }
 


### PR DESCRIPTION
PostgreSQL supports inheritance of user roles. Members of a parent role
can switch its role to the parent role. By changing role before running
CREATE statements, the parent role is used as the owner of the new
objects. This is useful especially if we adopting following operation:
(1) owner of objects are always a parent role and members can be rotated
or deleted at anytime, (2) the owner of tables loaded by a bulk loading
is always the same parent role while login passwords are managed per
person basis.

This operation is more effecitive if the members are created with
NOINHERIT option.

This change adds a new option `set_role: <ROLE_NAME>` to
embulk-output-postgresql support the use case.

Although MySQL and Oracle also support SET ROLE syntax, this change
doesn't change code for them as of now primarily because they support
additional syntax extensions. Redshift doesn't support role inheritance
or SET ROLE.
