### PR TITLE
Changed the maximum number of temporary tables from 1000 to 100000.

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -667,7 +667,7 @@ public abstract class AbstractJdbcOutputPlugin
                         String namePrefix = generateIntermediateTableNamePrefix(task.getActualTable().getTableName(), con, 3,
                                 task.getFeatures().getMaxTableNameLength(), task.getFeatures().getTableNameLengthSemantics());
                         for (int taskIndex = 0; taskIndex < taskCount; taskIndex++) {
-                            String tableName = namePrefix + String.format("%03d", taskIndex % 1000);
+                            String tableName = namePrefix + String.format("%05d", taskIndex % 100000);
                             table = buildIntermediateTableId(con, task, tableName);
                             // if table already exists, SQLException will be thrown
                             con.createTable(table, newTableSchema, task.getCreateTableConstraint(), task.getCreateTableOption());


### PR DESCRIPTION
Changed the maximum number of temporary tables from 1000 to 100000.

I have encountered a problem with huge table inserts failing, so I propose to expand the temporary table limit.
