### PR TITLE
Map an Embulk config directly to ZoneId with embulk-util-config's ZoneIdModule

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumnOption.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcColumnOption.java
@@ -1,5 +1,6 @@
 package org.embulk.output.jdbc;
 
+import java.time.ZoneId;
 import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
@@ -22,5 +23,5 @@ public interface JdbcColumnOption
 
     @Config("timezone")
     @ConfigDefault("null")
-    public Optional<String> getTimeZone();
+    public Optional<ZoneId> getTimeZone();
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/ColumnSetterFactory.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/setter/ColumnSetterFactory.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.Optional;
 import java.sql.Types;
+import java.time.ZoneId;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Exec;
 import org.embulk.output.jdbc.BatchInsert;
@@ -16,9 +17,9 @@ import org.embulk.util.timestamp.TimestampFormatter;
 public class ColumnSetterFactory
 {
     protected final BatchInsert batch;
-    protected final String defaultTimeZone;
+    protected final ZoneId defaultTimeZone;
 
-    public ColumnSetterFactory(final BatchInsert batch, final String defaultTimeZone)
+    public ColumnSetterFactory(final BatchInsert batch, final ZoneId defaultTimeZone)
     {
         this.batch = batch;
         this.defaultTimeZone = defaultTimeZone;
@@ -79,8 +80,8 @@ public class ColumnSetterFactory
     protected TimestampFormatter newTimestampFormatter(JdbcColumnOption option)
     {
         final String format = option.getTimestampFormat();
-        final String timezone = option.getTimeZone().orElse(this.defaultTimeZone);
-        return TimestampFormatter.builder(format, true).setDefaultZoneFromString(timezone).build();
+        final ZoneId timezone = option.getTimeZone().orElse(this.defaultTimeZone);
+        return TimestampFormatter.builder(format, true).setDefaultZoneId(timezone).build();
     }
 
     protected Calendar newCalendar(JdbcColumnOption option)
@@ -88,7 +89,7 @@ public class ColumnSetterFactory
         return Calendar.getInstance(TimeZone.getTimeZone(getTimeZone(option)), Locale.ENGLISH);
     }
 
-    protected String getTimeZone(JdbcColumnOption option)
+    protected ZoneId getTimeZone(JdbcColumnOption option)
     {
         return option.getTimeZone().orElse(defaultTimeZone);
     }

--- a/embulk-output-mysql/src/test/java/org/embulk/output/mysql/BasicTest.java
+++ b/embulk-output-mysql/src/test/java/org/embulk/output/mysql/BasicTest.java
@@ -91,12 +91,16 @@ public class BasicTest
         try {
             embulk.runOutput(baseConfig.merge(loadYamlResource(embulk, "test_invalid_time_zone.yml")), in1);
         } catch (final PartialExecutionException ex) {
-            final Throwable cause = ex.getCause();
-            assertThat(cause, instanceOf(ConfigException.class));
-            assertThat(cause.getMessage(), is("Time zone 'Somewhere/Some_City' is not recognised."));
-            return;
+            Throwable cause = ex.getCause();
+            while (cause != null) {
+                if (cause.getMessage() != null
+                            && cause.getMessage().contains("\"Somewhere/Some_City\" is not recognized as a timezone name.")) {
+                    return;
+                }
+                cause = cause.getCause();
+            }
         }
-        fail();
+        fail("It did not throw an expected Exception.");
     }
 
     private Path toPath(String fileName) throws URISyntaxException

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/PostgreSQLOutputPlugin.java
@@ -3,6 +3,7 @@ package org.embulk.output;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.ZoneId;
 import java.util.Properties;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -199,7 +200,7 @@ public class PostgreSQLOutputPlugin
     }
 
     @Override
-    protected ColumnSetterFactory newColumnSetterFactory(final BatchInsert batch, final String defaultTimeZone)
+    protected ColumnSetterFactory newColumnSetterFactory(final BatchInsert batch, final ZoneId defaultTimeZone)
     {
         return new PostgreSQLColumnSetterFactory(batch, defaultTimeZone);
     }

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/setter/PostgreSQLColumnSetterFactory.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/setter/PostgreSQLColumnSetterFactory.java
@@ -1,5 +1,6 @@
 package org.embulk.output.postgresql.setter;
 
+import java.time.ZoneId;
 import org.embulk.output.jdbc.BatchInsert;
 import org.embulk.output.jdbc.JdbcColumn;
 import org.embulk.output.jdbc.JdbcColumnOption;
@@ -10,7 +11,7 @@ import org.embulk.output.jdbc.setter.JsonColumnSetter;
 public class PostgreSQLColumnSetterFactory
         extends ColumnSetterFactory
 {
-    public PostgreSQLColumnSetterFactory(final BatchInsert batch, final String defaultTimeZone)
+    public PostgreSQLColumnSetterFactory(final BatchInsert batch, final ZoneId defaultTimeZone)
     {
         super(batch, defaultTimeZone);
     }

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
@@ -18,6 +18,7 @@ import org.embulk.util.config.ConfigDefault;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.Properties;
 import java.util.Arrays;
 import java.util.Collections;
@@ -302,7 +303,7 @@ public class SQLServerOutputPlugin
     }
 
     @Override
-    protected ColumnSetterFactory newColumnSetterFactory(final BatchInsert batch, final String defaultTimeZone)
+    protected ColumnSetterFactory newColumnSetterFactory(final BatchInsert batch, final ZoneId defaultTimeZone)
     {
         return new SQLServerColumnSetterFactory(batch, defaultTimeZone);
     }


### PR DESCRIPTION
Counter to the past changes in #275. #275 replaced Joda-Time's `DateTimeZone` to `String`, and introduced an explicit check against invalid time zones.

We have `embulk-util-config:0.3.0` for `embulk-input-jdbc` now by #292. It has an additional Jackson `Module` to map an Embulk config into `java.time.ZoneId` directly with some validation.
* https://github.com/embulk/embulk-util-config/pull/16
* https://github.com/embulk/embulk-util-config/pull/22

We can replace the explicit check against invalid time zones by `ZoneIdModule`.

This PR follows #292.