### PR TITLE
Nominate developers in embulk-output-jdbc/mysql/postgresql/redshift/sqlserver

### DIFF
--- a/embulk-output-jdbc/build.gradle
+++ b/embulk-output-jdbc/build.gradle
@@ -6,3 +6,42 @@ embulkPlugin {
     category = "output"
     type = "jdbc"
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                developers {
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "Hitoshi Tanaka"
+                        email = "thitoshi@cac.co.jp"
+                    }
+                    developer {
+                        name = "takumakanari"
+                        email = "chemtrails.t@gmail.com"
+                    }
+                    developer {
+                        name = "Tomohiro Hashidate"
+                        email = "kakyoin.hierophant@gmail.com"
+                    }
+                    developer {
+                        name = "Megumi Tomita"
+                        email = "tomykaira@gmail.com"
+                    }
+                    developer {
+                        name = "Hiroyuki Sato"
+                        email = "hiroysato@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                }
+           }
+        }
+    }
+}

--- a/embulk-output-jdbc/build.gradle
+++ b/embulk-output-jdbc/build.gradle
@@ -29,10 +29,6 @@ publishing {
                         email = "kakyoin.hierophant@gmail.com"
                     }
                     developer {
-                        name = "Megumi Tomita"
-                        email = "tomykaira@gmail.com"
-                    }
-                    developer {
                         name = "Hiroyuki Sato"
                         email = "hiroysato@gmail.com"
                     }

--- a/embulk-output-mysql/build.gradle
+++ b/embulk-output-mysql/build.gradle
@@ -40,10 +40,6 @@ publishing {
                         email = "kakyoin.hierophant@gmail.com"
                     }
                     developer {
-                        name = "Megumi Tomita"
-                        email = "tomykaira@gmail.com"
-                    }
-                    developer {
                         name = "Hiroyuki Sato"
                         email = "hiroysato@gmail.com"
                     }

--- a/embulk-output-mysql/build.gradle
+++ b/embulk-output-mysql/build.gradle
@@ -17,3 +17,42 @@ embulkPlugin {
     category = "output"
     type = "mysql"
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                developers {
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "takumakanari"
+                        email = "chemtrails.t@gmail.com"
+                    }
+                    developer {
+                        name = "Hitoshi Tanaka"
+                        email = "thitoshi@cac.co.jp"
+                    }
+                    developer {
+                        name = "Tomohiro Hashidate"
+                        email = "kakyoin.hierophant@gmail.com"
+                    }
+                    developer {
+                        name = "Megumi Tomita"
+                        email = "tomykaira@gmail.com"
+                    }
+                    developer {
+                        name = "Hiroyuki Sato"
+                        email = "hiroysato@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/embulk-output-postgresql/build.gradle
+++ b/embulk-output-postgresql/build.gradle
@@ -37,10 +37,6 @@ publishing {
                         email = "thitoshi@cac.co.jp"
                     }
                     developer {
-                        name = "Megumi Tomita"
-                        email = "tomykaira@gmail.com"
-                    }
-                    developer {
                         name = "Hiroyuki Sato"
                         email = "hiroysato@gmail.com"
                     }

--- a/embulk-output-postgresql/build.gradle
+++ b/embulk-output-postgresql/build.gradle
@@ -18,3 +18,38 @@ embulkPlugin {
     category = "output"
     type = "postgresql"
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                developers {
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "takumakanari"
+                        email = "chemtrails.t@gmail.com"
+                    }
+                    developer {
+                        name = "Hitoshi Tanaka"
+                        email = "thitoshi@cac.co.jp"
+                    }
+                    developer {
+                        name = "Megumi Tomita"
+                        email = "tomykaira@gmail.com"
+                    }
+                    developer {
+                        name = "Hiroyuki Sato"
+                        email = "hiroysato@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/embulk-output-redshift/build.gradle
+++ b/embulk-output-redshift/build.gradle
@@ -31,3 +31,62 @@ embulkPlugin {
     category = "output"
     type = "redshift"
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                developers {
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "Hitoshi Tanaka"
+                        email = "thitoshi@cac.co.jp"
+                    }
+                    developer {
+                        name = "Hiroyuki Sato"
+                        email = "hiroysato@gmail.com"
+                    }
+                    // developer {  // https://github.com/embulk/embulk-output-jdbc/commit/97f3a4ba14ecb99b9bdfa03831a84cb7e1a8e970
+                    //     name = "Lance Norskog"
+                    //     email = "lance@edmodo.com"
+                    // }
+                    developer {
+                        name = "Roland Rifandi Utama"
+                        email = "roland_hawk@yahoo.com"
+                    }
+                    developer {
+                        name = "Megumi Tomita"
+                        email = "tomykaira@gmail.com"
+                    }
+                    developer {
+                        name = "Antoine Augusti"
+                        email = "antoine@drivy.com"
+                    }
+                    // developer {  // https://github.com/embulk/embulk-output-jdbc/pull/142
+                    //     name = "Vincent Martinez"
+                    //     email = ""
+                    // }
+                    developer {
+                        name = "Toyama Hiroshi"
+                        email = "toyama0919@gmail.com"
+                    }
+                    developer {
+                        name = "Michael Jalkio"
+                        email = "mjalkio@classy.org"
+                    }
+                    developer {
+                        name = "Yutaka Nishimura"
+                        email = "ytk.nishimura@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/embulk-output-redshift/build.gradle
+++ b/embulk-output-redshift/build.gradle
@@ -49,33 +49,13 @@ publishing {
                         name = "Hiroyuki Sato"
                         email = "hiroysato@gmail.com"
                     }
-                    // developer {  // https://github.com/embulk/embulk-output-jdbc/commit/97f3a4ba14ecb99b9bdfa03831a84cb7e1a8e970
-                    //     name = "Lance Norskog"
-                    //     email = "lance@edmodo.com"
-                    // }
-                    developer {
-                        name = "Roland Rifandi Utama"
-                        email = "roland_hawk@yahoo.com"
-                    }
-                    developer {
-                        name = "Megumi Tomita"
-                        email = "tomykaira@gmail.com"
-                    }
                     developer {
                         name = "Antoine Augusti"
-                        email = "antoine@drivy.com"
-                    }
-                    // developer {  // https://github.com/embulk/embulk-output-jdbc/pull/142
-                    //     name = "Vincent Martinez"
-                    //     email = ""
-                    // }
-                    developer {
-                        name = "Toyama Hiroshi"
-                        email = "toyama0919@gmail.com"
+                        email = "hi@antoine-augusti.fr"
                     }
                     developer {
                         name = "Michael Jalkio"
-                        email = "mjalkio@classy.org"
+                        email = "mjalkio@gmail.com"
                     }
                     developer {
                         name = "Yutaka Nishimura"

--- a/embulk-output-sqlserver/build.gradle
+++ b/embulk-output-sqlserver/build.gradle
@@ -26,3 +26,38 @@ embulkPlugin {
     category = "output"
     type = "sqlserver"
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                developers {
+                    developer {
+                        name = "Hitoshi Tanaka"
+                        email = "thitoshi@cac.co.jp"
+                    }
+                    developer {
+                        name = "Megumi Tomita"
+                        email = "tomykaira@gmail.com"
+                    }
+                    developer {
+                        name = "uu59"
+                        email = "k@uu59.org"
+                    }
+                    developer {
+                        name = "kitsuy"
+                        email = "kitsuy@eac.ne.jp"
+                    }
+                    developer {
+                        name = "Hieu Duong"
+                        email = "duongminhhieu89@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/embulk-output-sqlserver/build.gradle
+++ b/embulk-output-sqlserver/build.gradle
@@ -37,16 +37,8 @@ publishing {
                         email = "thitoshi@cac.co.jp"
                     }
                     developer {
-                        name = "Megumi Tomita"
-                        email = "tomykaira@gmail.com"
-                    }
-                    developer {
-                        name = "uu59"
-                        email = "k@uu59.org"
-                    }
-                    developer {
-                        name = "kitsuy"
-                        email = "kitsuy@eac.ne.jp"
+                        name = "Yui Kitsu"
+                        email = "kitsuyui@kitsuyui.com"
                     }
                     developer {
                         name = "Hieu Duong"


### PR DESCRIPTION
We're going to release JARs of `embulk-output-jdbc/...` to Maven Central from 0.10.0 (#294).

Maven Central needs the `<developers>` section available in `pom.xml`. In this chance, trying to nominate developers who have contributed a important portion in `embulk-input-jdbc/mysql/postgresql/redshift` from the Git log.