### PR TITLE
Fix a compile error in embulk-output-sqlserver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,3 +156,14 @@ jobs:
           name: redshift
           path: embulk-output-redshift/build/reports/tests/test
           if-no-files-found: ignore
+  sqlserver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'zulu'
+      - name: Build-only
+        run: ./gradlew --stacktrace :embulk-output-sqlserver:compileJava :embulk-output-sqlserver:compileTestJava

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/setter/SQLServerColumnSetterFactory.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/setter/SQLServerColumnSetterFactory.java
@@ -1,7 +1,7 @@
 package org.embulk.output.sqlserver.setter;
 
 import java.sql.Types;
-
+import java.time.ZoneId;
 import org.embulk.output.jdbc.BatchInsert;
 import org.embulk.output.jdbc.JdbcColumn;
 import org.embulk.output.jdbc.JdbcColumnOption;
@@ -12,7 +12,7 @@ import org.embulk.output.jdbc.setter.StringColumnSetter;
 public class SQLServerColumnSetterFactory
         extends ColumnSetterFactory
 {
-    public SQLServerColumnSetterFactory(final BatchInsert batch, final String defaultTimeZone)
+    public SQLServerColumnSetterFactory(final BatchInsert batch, final ZoneId defaultTimeZone)
     {
         super(batch, defaultTimeZone);
     }


### PR DESCRIPTION
I found that `embulk-output-sqlserver` was failing to compile when I tried to release 0.10.0. We were not able to detect it beforehand as it was not tested in GitHub Actions.

This PR fixes the compile error, and adds "build-only" check in GitHub Actions for the time being.

Testing `embulk-output-sqlserver` on GitHub Actions would be addressed in #280 later...