### PR TITLE
Change AWS SDK to the version that support OIDC

### DIFF
--- a/embulk-output-redshift/build.gradle
+++ b/embulk-output-redshift/build.gradle
@@ -3,13 +3,13 @@ dependencies {
     compile(project(path: ":embulk-output-postgresql", configuration: "runtimeElements"))
     compile "org.postgresql:postgresql:9.4-1205-jdbc41"
 
-    compile("com.amazonaws:aws-java-sdk-s3:1.11.523") {
+    compile("com.amazonaws:aws-java-sdk-s3:1.11.704") {
         exclude group: "joda-time", module: "joda-time"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     }
-    compile("com.amazonaws:aws-java-sdk-sts:1.11.523") {
+    compile("com.amazonaws:aws-java-sdk-sts:1.11.704") {
         exclude group: "joda-time", module: "joda-time"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"

--- a/embulk-output-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,22 +1,22 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.amazonaws:aws-java-sdk-core:1.11.523
-com.amazonaws:aws-java-sdk-kms:1.11.523
-com.amazonaws:aws-java-sdk-s3:1.11.523
-com.amazonaws:aws-java-sdk-sts:1.11.523
-com.amazonaws:jmespath-java:1.11.523
+com.amazonaws:aws-java-sdk-core:1.11.704
+com.amazonaws:aws-java-sdk-kms:1.11.704
+com.amazonaws:aws-java-sdk-s3:1.11.704
+com.amazonaws:aws-java-sdk-sts:1.11.704
+com.amazonaws:jmespath-java:1.11.704
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 commons-logging:commons-logging:1.2
 javax.validation:validation-api:1.1.0.Final
 joda-time:joda-time:2.9.2
-org.apache.httpcomponents:httpclient:4.5.5
-org.apache.httpcomponents:httpcore:4.4.9
+org.apache.httpcomponents:httpclient:4.5.9
+org.apache.httpcomponents:httpcore:4.4.11
 org.embulk:embulk-util-aws-credentials:0.4.0
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-json:0.1.1


### PR DESCRIPTION
OIDC support will improve `embul` usability in EKS.
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html