### PR TITLE
Use execute() instead of executeUpdate() for afterLoad/beforeLoad

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -608,7 +608,7 @@ public abstract class AbstractJdbcOutputPlugin
             // direct modify mode doesn't need intermediate tables.
             task.setIntermediateTables(Optional.<List<TableIdentifier>>empty());
             if (task.getBeforeLoad().isPresent()) {
-                con.executeSql(task.getBeforeLoad().get());
+                con.executeSqlStatement(task.getBeforeLoad().get());
             }
         }
 
@@ -874,7 +874,7 @@ public abstract class AbstractJdbcOutputPlugin
         case MERGE_DIRECT:
             // already loaded
             if (task.getAfterLoad().isPresent()) {
-                con.executeSql(task.getAfterLoad().get());
+                con.executeSqlStatement(task.getAfterLoad().get());
             }
             break;
 

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -608,7 +608,7 @@ public abstract class AbstractJdbcOutputPlugin
             // direct modify mode doesn't need intermediate tables.
             task.setIntermediateTables(Optional.<List<TableIdentifier>>empty());
             if (task.getBeforeLoad().isPresent()) {
-                con.executeSqlStatement(task.getBeforeLoad().get());
+                con.executeInNewStatement(task.getBeforeLoad().get());
             }
         }
 
@@ -874,7 +874,7 @@ public abstract class AbstractJdbcOutputPlugin
         case MERGE_DIRECT:
             // already loaded
             if (task.getAfterLoad().isPresent()) {
-                con.executeSqlStatement(task.getAfterLoad().get());
+                con.executeInNewStatement(task.getAfterLoad().get());
             }
             break;
 

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -383,6 +383,19 @@ public class JdbcOutputConnection
         }
     }
 
+    protected void executeSqlStatement(String sql) throws SQLException
+    {
+        Statement stmt = connection.createStatement();
+        try {
+            execute(stmt, sql);
+            commitIfNecessary(connection);
+        } catch (SQLException ex) {
+            throw safeRollback(connection, ex);
+        } finally {
+            stmt.close();
+        }
+    }
+
     protected void collectInsert(List<TableIdentifier> fromTables, JdbcSchema schema, TableIdentifier toTable,
             boolean truncateDestinationFirst, Optional<String> preSql, Optional<String> postSql) throws SQLException
     {
@@ -398,14 +411,14 @@ public class JdbcOutputConnection
             }
 
             if (preSql.isPresent()) {
-                executeUpdate(stmt, preSql.get());
+                execute(stmt, preSql.get());
             }
 
             String sql = buildCollectInsertSql(fromTables, schema, toTable);
             executeUpdate(stmt, sql);
 
             if (postSql.isPresent()) {
-                executeUpdate(stmt, postSql.get());
+                execute(stmt, postSql.get());
             }
 
             commitIfNecessary(connection);
@@ -462,14 +475,14 @@ public class JdbcOutputConnection
         Statement stmt = connection.createStatement();
         try {
             if (preSql.isPresent()) {
-                executeUpdate(stmt, preSql.get());
+                execute(stmt, preSql.get());
             }
 
             String sql = buildCollectMergeSql(fromTables, schema, toTable, mergeConfig);
             executeUpdate(stmt, sql);
 
             if (postSql.isPresent()) {
-                executeUpdate(stmt, postSql.get());
+                execute(stmt, postSql.get());
             }
 
             commitIfNecessary(connection);
@@ -494,7 +507,7 @@ public class JdbcOutputConnection
             executeUpdate(stmt, buildRenameTableSql(fromTable, toTable));
 
             if (postSql.isPresent()) {
-                executeUpdate(stmt, postSql.get());
+                execute(stmt, postSql.get());
             }
 
             commitIfNecessary(connection);
@@ -628,6 +641,20 @@ public class JdbcOutputConnection
             logger.info(String.format("> %.2f seconds (%,d rows)", seconds, count));
         }
         return count;
+    }
+
+    protected boolean execute(Statement stmt, String sql) throws SQLException
+    {
+        logger.info("SQL: " + sql);
+        long startTime = System.currentTimeMillis();
+        boolean result = stmt.execute(sql);
+        double seconds = (System.currentTimeMillis() - startTime) / 1000.0;
+        if (result) {
+            logger.info(String.format("> succeed %.2f seconds", seconds));
+        } else {
+            logger.info(String.format("> failed %.2f seconds", seconds));
+        }
+        return result;
     }
 
     protected void commitIfNecessary(Connection con) throws SQLException

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -370,7 +370,12 @@ public class JdbcOutputConnection
         throw new UnsupportedOperationException("not implemented");
     }
 
+    @Deprecated // Use executeUpdateInNewStatement instead.
     protected void executeSql(String sql) throws SQLException
+    {
+        executeUpdateInNewStatement(sql);
+    }
+    protected void executeUpdateInNewStatement(String sql) throws SQLException
     {
         Statement stmt = connection.createStatement();
         try {
@@ -383,7 +388,7 @@ public class JdbcOutputConnection
         }
     }
 
-    protected void executeSqlStatement(String sql) throws SQLException
+    protected void executeInNewStatement(String sql) throws SQLException
     {
         Statement stmt = connection.createStatement();
         try {


### PR DESCRIPTION
Fixing #312 

I added test code to embulk-output-postgresql in #319.

@dmikurube and @hito4t 
Could you check when you get a chance?

Ref: https://embulk-dev.zulipchat.com/#narrow/stream/352993-embulk/topic/output-postgresql.20.3A.20support.20select.20in.20the.20after_load/near/345032157
