### PR TITLE
Use NVARCHAR(max) for CLOB, instead of TEXT, when creating a table in SQLServer

### DIFF
--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnection.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnection.java
@@ -44,7 +44,7 @@ public class SQLServerOutputConnection
         case "BOOLEAN":
             return "BIT";
         case "CLOB":
-            return "TEXT";
+            return "NVARCHAR(max)";
         case "TIMESTAMP":
             return "DATETIME2";
         case "NVARCHAR":


### PR DESCRIPTION
Currently, the `embulk-output-sqlserver` mapped `CLOB` to `TEXT` type. This mapping will not work with some Japanese collation. It will display error message like `SQL Error [4188] [S0001]: Column or parameter 'colume1' has type 'text' and collation 'Japanese_XJIS_140_CI_AS'. The legacy LOB types do not support UTF-8 or UTF-16 encodings. Use types varchar(max), nvarchar(max) or a collation which does not have the _SC or _UTF8 flags.`. Moreover, as `TEXT` type is deprecated and removed in the future version (https://learn.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-2016). So this PR will map `CLOB` type to `NVARCHAR(max)` type.

Ref: https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-2017#Unicode_Defn