### PR TITLE
truncate insert description update

### DIFF
--- a/embulk-output-jdbc/README.md
+++ b/embulk-output-jdbc/README.md
@@ -47,7 +47,7 @@ Generic JDBC output plugin for Embulk loads records to a database using a JDBC d
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`) the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates the target table (with SQL `DELETE FROM`, not `TRUNCATE`) right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-jdbc/README.md
+++ b/embulk-output-jdbc/README.md
@@ -47,7 +47,7 @@ Generic JDBC output plugin for Embulk loads records to a database using a JDBC d
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`) the target table right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-mysql/README.md
+++ b/embulk-output-mysql/README.md
@@ -49,7 +49,7 @@ MySQL output plugin for Embulk loads records to MySQL.
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates the target table (with SQL `DELETE FROM`, not `TRUNCATE`) right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-mysql/README.md
+++ b/embulk-output-mysql/README.md
@@ -49,7 +49,7 @@ MySQL output plugin for Embulk loads records to MySQL.
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-postgresql/README.md
+++ b/embulk-output-postgresql/README.md
@@ -52,7 +52,7 @@ PostgreSQL output plugin for Embulk loads records to PostgreSQL.
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates the target table (with SQL `DELETE FROM`, not `TRUNCATE`) right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-postgresql/README.md
+++ b/embulk-output-postgresql/README.md
@@ -52,7 +52,7 @@ PostgreSQL output plugin for Embulk loads records to PostgreSQL.
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -103,7 +103,7 @@ Redshift output plugin for Embulk loads records to Redshift.
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates the target table (with SQL `DELETE FROM`, not `TRUNCATE`) right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -103,7 +103,7 @@ Redshift output plugin for Embulk loads records to Redshift.
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -62,7 +62,7 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates the target table (with SQL `DELETE FROM`, not `TRUNCATE`) right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:

--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -62,7 +62,7 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   * Transactional: No. If fails, the target table could have some rows inserted.
   * Resumable: No.
 * **truncate_insert**:
-  * Behavior: Same with `insert` mode excepting that it truncates the target table right before the last `INSERT ...` query.
+  * Behavior: Same with `insert` mode excepting that it truncates(using `delete from`, not using `truncate`)  the target table right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:


### PR DESCRIPTION
mode:tuncate_insert does not actually use the truncate statement, it executes the delete statement

https://github.com/embulk/embulk-output-jdbc/blob/dfb2192cd0162ac32b9111f1de7f28177e4cf902/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java#L890-L897
https://github.com/embulk/embulk-output-jdbc/blob/dfb2192cd0162ac32b9111f1de7f28177e4cf902/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java#L386-L417
https://github.com/embulk/embulk-output-jdbc/blob/dfb2192cd0162ac32b9111f1de7f28177e4cf902/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java#L419-L427

https://github.com/embulk/embulk-output-jdbc/pull/321#issuecomment-1630121862

I have updated description to your comment's
