### PR TITLE
Add logging to avoid loss of information when exception changes during retries

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -1369,7 +1369,18 @@ public abstract class AbstractJdbcOutputPlugin
                 SQLException ex = (SQLException) firstException;
                 String sqlState = ex.getSQLState();
                 int errorCode = ex.getErrorCode();
-                logger.error("{} ({}:{})", errorMessage, errorCode, sqlState);
+                logger.error("{} (first exception:{SQLState={}, ErrorCode={}})", errorMessage, errorCode, sqlState, ex);
+            } else {
+                logger.error("{} (first exception)", errorMessage, firstException);
+            }
+
+            if (lastException instanceof SQLException) {
+                SQLException ex = (SQLException) lastException;
+                String sqlState = ex.getSQLState();
+                int errorCode = ex.getErrorCode();
+                logger.error("{} (last exception:{SQLState={}, ErrorCode={}})", errorMessage, errorCode, sqlState, ex);
+            } else {
+                logger.error("{} (last exception)", errorMessage, lastException);
             }
         }
 


### PR DESCRIPTION
If a raised exception changes during retry executions and the exception is not retryable, the retrying is aborted instantly, but the information of the last exception is lost, because RetryExecutor throws only the first exception and OnRetry hook doesn't log about the last exception.

For example, like this:

```
2023-09-06 18:56:18.365 +0000 [WARN] (0018:task-0010): Operation fai
led (1213:40001), retrying 1/8 after 1 seconds. Message: Deadlock found when trying to get lock; try restarting transaction
2023-09-06 18:56:19.366 +0000 [ERROR] (0018:task-0010): Operation fa
iled (1213:40001)
```

In this situation, it is difficult to identify the root problem, so I would like to change to log also last exception.