### PR TITLE
Add CODEOWNERS as @embulk/jdbc-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@embulk/jdbc-maintainers


### PR DESCRIPTION
Similar to https://github.com/embulk/embulk-input-jdbc/pull/253, adding `CODEOWNERS`.