### PR TITLE
Swap name + drop instead of drop + rename in replace mode

### DIFF
--- a/embulk-output-mysql/README.md
+++ b/embulk-output-mysql/README.md
@@ -53,8 +53,8 @@ MySQL output plugin for Embulk loads records to MySQL.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:
-  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, drops the target table and alters the name of the intermediate table into the target table name.
-  * Transactional: No. If fails, the target table could be dropped (because MySQL can't rollback DDL).
+  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, swaps the intermediate table with target table by altering the names, and drops the intermediate table.
+  * Transactional: No. If fails, the intermediate table could remain (because MySQL can't rollback DDL).
   * Resumable: No.
 * **merge**:
   * Behavior: This mode writes rows to some intermediate tables first. If all those tasks run correctly, runs `INSERT INTO <target_table> SELECT * FROM <intermediate_table_1> UNION ALL SELECT * FROM <intermediate_table_2> UNION ALL ... ON DUPLICATE KEY UPDATE ...` query. Namely, if primary keys of a record in the intermediate tables already exist in the target table, the target record is updated by the intermediate record, otherwise the intermediate record is inserted. If the target table doesn't exist, it is created automatically.

--- a/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
+++ b/embulk-output-mysql/src/main/java/org/embulk/output/mysql/MySQLOutputConnection.java
@@ -102,6 +102,29 @@ public class MySQLOutputConnection
     }
 
     @Override
+    protected String buildSwapTablesSql(TableIdentifier fromTable, TableIdentifier toTable)
+    {
+        TableIdentifier tmpTable = new TableIdentifier(fromTable.getDatabase(), fromTable.getSchemaName(), fromTable.getTableName() + "_embulk_swap_tmp");
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("RENAME TABLE ");
+        quoteTableIdentifier(sb, fromTable);
+        sb.append(" TO ");
+        quoteTableIdentifier(sb, tmpTable);
+        sb.append(", ");
+        quoteTableIdentifier(sb, toTable);
+        sb.append(" TO ");
+        quoteTableIdentifier(sb, fromTable);
+        sb.append(", ");
+        quoteTableIdentifier(sb, tmpTable);
+        sb.append(" TO ");
+        quoteTableIdentifier(sb, toTable);
+
+        return sb.toString();
+    }
+
+    @Override
     protected String buildColumnTypeName(JdbcColumn c)
     {
         switch(c.getSimpleTypeName()) {

--- a/embulk-output-postgresql/README.md
+++ b/embulk-output-postgresql/README.md
@@ -56,7 +56,7 @@ PostgreSQL output plugin for Embulk loads records to PostgreSQL.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:
-  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, drops the target table and alters the name of the intermediate table into the target table name.
+  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, swaps the intermediate table with target table by altering the names, and drops the intermediate table.
   * Transactional: Yes.
   * Resumable: No.
 * **merge**:

--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -115,7 +115,7 @@ Redshift output plugin for Embulk loads records to Redshift.
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:
-  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, drops the target table and alters the name of the intermediate table into the target table name.
+  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, swaps the intermediate table with target table by altering the names, and drops the intermediate table.
   * Transactional: Yes.
   * Resumable: No.
 * **merge**:

--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -66,8 +66,8 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   * Transactional: Yes.
   * Resumable: No.
 * **replace**:
-  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, drops the target table and alters the name of the intermediate table into the target table name.
-  * Transactional: No. If fails, the target table could be dropped (because SQL Server can't rollback DDL).
+  * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, swaps the intermediate table with target table by altering the names, and drops the intermediate table.
+  * Transactional: Yes.
   * Resumable: No.
 * **merge**:
   * Behavior: This mode writes rows to some intermediate tables first. If all those tasks run correctly, runs `MERGE INTO ... WHEN MATCHED THEN UPDATE ...  WHEN NOT MATCHED THEN INSERT ...` query. Namely, if merge keys of a record in the intermediate tables already exist in the target table, the target record is updated by the intermediate record, otherwise the intermediate record is inserted. If the target table doesn't exist, it is created automatically.


### PR DESCRIPTION
https://github.com/embulk/embulk-output-jdbc/tree/master/embulk-output-mysql#modes

This pull request aims to enhance the safety of the replace mode for embulk-output-mysql, which can inadvertently drop the target table on failure, due to MySQL's implicit commit of DDL.

It changes to swap the names of intermediate and target table at first, and then drop the "intermediate" table.

In MySQL, the table rename operation can be executed in a single query, as outlined in the documentation here:
* https://dev.mysql.com/doc/refman/5.7/en/rename-table.html
* https://dev.mysql.com/doc/refman/8.0/en/rename-table.html

Therefore, The target table would never be dropped.
The DDL is transactional for other plugins, so it shouldn't change the behavior of replace mode.

I'm not sure enough whether this can be a breaking change, if in case, it might be better to implement it as a new mode.