### PR TITLE
Change Drop Table Method(dropTableIfExists)

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -121,8 +121,16 @@ public class JdbcOutputConnection
     protected void dropTableIfExists(Statement stmt, TableIdentifier table) throws SQLException
     {
         if (supportsTableIfExistsClause()) {
-            String sql = String.format("DROP TABLE IF EXISTS %s", quoteTableIdentifier(table));
-            executeUpdate(stmt, sql);
+            try {
+                String sql = String.format("DROP TABLE IF EXISTS %s", quoteTableIdentifier(table));
+                executeUpdate(stmt, sql);
+            }
+            catch (Exception ex) {
+                logger.warn("IF EXISTS Not Supported.");
+                if (tableExists(table)) {
+                    dropTable(stmt, table);
+                }
+            }
         } else {
             if (tableExists(table)) {
                 dropTable(stmt, table);


### PR DESCRIPTION
fix if exists command not support error 

- supportsTableIfExistsClause() method always true
![image](https://github.com/user-attachments/assets/ca651853-8f1f-4ea2-ad9a-1f21ef115762)


so my system print out this error

`
2024-08-29 10:13:48.061 +0900 [INFO] (0001:transaction): SQL: DROP TABLE IF EXISTS "CLAIM_INFO"
2024-08-29 10:13:48.065 +0900 [ERROR] (0001:transaction): Operation failed (first exception:{SQLState=933, ErrorCode=42000})
java.sql.SQLSyntaxErrorException: ORA-00933: SQL command not properly ended
at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:450)
at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:399)
at oracle.jdbc.driver.T4C8Oall.processError(T4C8Oall.java:1059)
at oracle.jdbc.driver.T4CTTIfun.receive(T4CTTIfun.java:522)
`
