### PR TITLE
Add getDataLength for numeric without precision

### DIFF
--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -267,6 +267,10 @@ public class PostgreSQLOutputConnection
             if (c.getDataLength() > MAX_NUMERIC_PRECISION || c.getDataLength() < MIN_NUMERIC_PRECISION) {
                 // getDataLength for numeric without precision will return 0 or 131089 .
                 // but cannot create column of numeric(0) and numeric(131089) .
+                // before PostgreSQL JDBC driver 42.2.23, return 131089. from 42.2.23 return 0.
+                // release note: https://jdbc.postgresql.org/changelogs/2021-07-06-42.2.23-release/
+                // issue: https://github.com/pgjdbc/pgjdbc/issues/2188
+                // pull request: https://github.com/pgjdbc/pgjdbc/pull/2189
                 return "NUMERIC";
             }
             break;

--- a/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
+++ b/embulk-output-postgresql/src/main/java/org/embulk/output/postgresql/PostgreSQLOutputConnection.java
@@ -16,6 +16,7 @@ import org.postgresql.core.BaseConnection;
 public class PostgreSQLOutputConnection
         extends JdbcOutputConnection
 {
+    private static final int MIN_NUMERIC_PRECISION = 1;
     private static final int MAX_NUMERIC_PRECISION = 1000;
 
     public PostgreSQLOutputConnection(Connection connection, String schemaName, String roleName)
@@ -263,9 +264,9 @@ public class PostgreSQLOutputConnection
             }
             break;
         case "NUMERIC": // only "NUMERIC" because PostgreSQL JDBC driver will return also "NUMERIC" for the type name of decimal.
-            if (c.getDataLength() > MAX_NUMERIC_PRECISION) {
-                // getDataLength for numeric without precision will return 131089 .
-                // but cannot create column of numeric(131089) .
+            if (c.getDataLength() > MAX_NUMERIC_PRECISION || c.getDataLength() < MIN_NUMERIC_PRECISION) {
+                // getDataLength for numeric without precision will return 0 or 131089 .
+                // but cannot create column of numeric(0) and numeric(131089) .
                 return "NUMERIC";
             }
             break;


### PR DESCRIPTION
This pull request is fixes issue #350 